### PR TITLE
r/newrelic_alert_condition: Allow zero threshold value for terms

### DIFF
--- a/newrelic/resource_newrelic_alert_condition.go
+++ b/newrelic/resource_newrelic_alert_condition.go
@@ -11,7 +11,7 @@ import (
 )
 
 var alertConditionTypes = map[string][]string{
-	"apm_app_metric": []string{
+	"apm_app_metric": {
 		"apdex",
 		"error_percentage",
 		"response_time_background",
@@ -20,14 +20,14 @@ var alertConditionTypes = map[string][]string{
 		"throughput_web",
 		"user_defined",
 	},
-	"apm_kt_metric": []string{
+	"apm_kt_metric": {
 		"apdex",
 		"error_count",
 		"error_percentage",
 		"response_time",
 		"throughput",
 	},
-	"browser_metric": []string{
+	"browser_metric": {
 		"ajax_response_time",
 		"ajax_throughput",
 		"dom_processing",
@@ -41,7 +41,7 @@ var alertConditionTypes = map[string][]string{
 		"user_defined",
 		"web_application",
 	},
-	"mobile_metric": []string{
+	"mobile_metric": {
 		"database",
 		"images",
 		"json",
@@ -52,7 +52,7 @@ var alertConditionTypes = map[string][]string{
 		"user_defined",
 		"view_loading",
 	},
-	"servers_metric": []string{
+	"servers_metric": {
 		"cpu_percentage",
 		"disk_io_percentage",
 		"fullest_disk_percentage",

--- a/vendor/github.com/paultyng/go-newrelic/api/client.go
+++ b/vendor/github.com/paultyng/go-newrelic/api/client.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"crypto/tls"
 	"fmt"
 
 	"github.com/tomnomnom/linkheader"
@@ -32,9 +33,10 @@ type ErrorDetail struct {
 
 // Config contains all the configuration data for the API Client
 type Config struct {
-	APIKey  string
-	BaseURL string
-	Debug   bool
+	APIKey    string
+	BaseURL   string
+	Debug     bool
+	TLSConfig *tls.Config
 }
 
 // New returns a new Client for the specified apiKey.
@@ -49,6 +51,9 @@ func New(config Config) Client {
 	r.SetHeader("X-Api-Key", config.APIKey)
 	r.SetHostURL(baseURL)
 
+	if config.TLSConfig != nil {
+		r.SetTLSClientConfig(config.TLSConfig)
+	}
 	if config.Debug {
 		r.SetDebug(true)
 	}

--- a/vendor/github.com/paultyng/go-newrelic/api/types.go
+++ b/vendor/github.com/paultyng/go-newrelic/api/types.go
@@ -41,7 +41,7 @@ type AlertConditionTerm struct {
 	Duration     int     `json:"duration,string,omitempty"`
 	Operator     string  `json:"operator,omitempty"`
 	Priority     string  `json:"priority,omitempty"`
-	Threshold    float64 `json:"threshold,string,omitempty"`
+	Threshold    float64 `json:"threshold,string"`
 	TimeFunction string  `json:"time_function,omitempty"`
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -578,10 +578,10 @@
 			"revisionTime": "2016-11-16T22:44:47Z"
 		},
 		{
-			"checksumSHA1": "SUK6xOTZDwljlX/AoHAmgoz0e1E=",
+			"checksumSHA1": "aEV+rDkw6bb+NklToOHumEq4vQA=",
 			"path": "github.com/paultyng/go-newrelic/api",
-			"revision": "5fbf16b273dd4b544c9588450c58711d9f46f912",
-			"revisionTime": "2017-03-27T18:23:21Z"
+			"revision": "48c279af9399a0a00eca683a36dad18a929ea943",
+			"revisionTime": "2017-07-10T20:07:19Z"
 		},
 		{
 			"checksumSHA1": "u5s2PZ7fzCOqQX7bVPf9IJ+qNLQ=",

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -68,4 +68,4 @@ resource "newrelic_alert_policy_channel" "alert_email" {
 
 The following arguments are supported:
 
-* `api_key` - (Required) Your New Relic API key.
+* `api_key` - (Required) Your New Relic API key. Can also use `NEWRELIC_API_KEY` environment variable.


### PR DESCRIPTION
Adds a test to verify a zero-value for term thresholds

```
$ make testacc TEST=./newrelic TESTARGS="-run=TestAccNewRelicAlertCondition_ZeroThreshold"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./newrelic -v -run=TestAccNewRelicAlertCondition_ZeroThreshold -timeout 120m
=== RUN   TestAccNewRelicAlertCondition_ZeroThreshold
--- PASS: TestAccNewRelicAlertCondition_ZeroThreshold (12.52s)
PASS
ok      github.com/terraform-providers/terraform-provider-newrelic/newrelic     12.528s
```

Depends on fix: https://github.com/paultyng/go-newrelic/issues/6
Fixes: #12 
