### PR TITLE
Add support for dashboards API

### DIFF
--- a/newrelic/import_newrelic_dashboard_test.go
+++ b/newrelic/import_newrelic_dashboard_test.go
@@ -1,0 +1,30 @@
+package newrelic
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccNewRelicDashboard_import(t *testing.T) {
+	resourceName := "newrelic_dashboard.foo"
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckNewRelicDashboardConfig(rName),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/newrelic/provider.go
+++ b/newrelic/provider.go
@@ -34,6 +34,7 @@ func Provider() terraform.ResourceProvider {
 			"newrelic_nrql_alert_condition": resourceNewRelicNrqlAlertCondition(),
 			"newrelic_alert_policy":         resourceNewRelicAlertPolicy(),
 			"newrelic_alert_policy_channel": resourceNewRelicAlertPolicyChannel(),
+			"newrelic_dashboard":            resourceNewRelicDashboard(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/newrelic/resource_newrelic_dashboard.go
+++ b/newrelic/resource_newrelic_dashboard.go
@@ -116,7 +116,10 @@ func resourceNewRelicDashboardWidgetsHash(v interface{}) int {
 	return hashcode.String(buf.String())
 }
 
-func buildDashboardStruct(d *schema.ResourceData) *newrelic.Dashboard {
+// Assemble the *newrelic.Dashboard variable.
+//
+// Used by the newrelic_dashboard Create and Update functions.
+func expandDashboard(d *schema.ResourceData) *newrelic.Dashboard {
 	metadata := newrelic.DashboardMetadata{
 		Version: 1,
 	}
@@ -167,7 +170,10 @@ func buildDashboardStruct(d *schema.ResourceData) *newrelic.Dashboard {
 	return &dashboard
 }
 
-func readDashboardStruct(dashboard *newrelic.Dashboard, d *schema.ResourceData) error {
+// Unpack the *newrelic.Dashboard variable and set resource data.
+//
+// Used by the newrelic_dashboard Read function (resourceNewRelicDashboardRead)
+func flattenDashboard(dashboard *newrelic.Dashboard, d *schema.ResourceData) error {
 	d.Set("title", dashboard.Title)
 	d.Set("icon", dashboard.Icon)
 	d.Set("visibility", dashboard.Visibility)
@@ -203,7 +209,7 @@ func readDashboardStruct(dashboard *newrelic.Dashboard, d *schema.ResourceData) 
 
 func resourceNewRelicDashboardCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*newrelic.Client)
-	dashboard := buildDashboardStruct(d)
+	dashboard := expandDashboard(d)
 	log.Printf("[INFO] Creating New Relic dashboard: %s", dashboard.Title)
 
 	dashboard, err := client.CreateDashboard(*dashboard)
@@ -236,12 +242,12 @@ func resourceNewRelicDashboardRead(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	return readDashboardStruct(dashboard, d)
+	return flattenDashboard(dashboard, d)
 }
 
 func resourceNewRelicDashboardUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*newrelic.Client)
-	dashboard := buildDashboardStruct(d)
+	dashboard := expandDashboard(d)
 
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {

--- a/newrelic/resource_newrelic_dashboard.go
+++ b/newrelic/resource_newrelic_dashboard.go
@@ -120,8 +120,15 @@ func resourceNewRelicDashboardWidgetsHash(v interface{}) int {
 
 	row := m["row"].(int)
 	column := m["column"].(int)
+	width := m["width"].(int)
+	height := m["height"].(int)
+	nrql := m["nrql"].(string)
+	title := m["title"].(string)
+	notes := m["notes"].(string)
+	viz := m["visualization"].(string)
 
-	buf.WriteString(fmt.Sprintf("%d-%d", row, column))
+	buf.WriteString(fmt.Sprintf("%d-%d-%d-%d-%s-%s-%s-%s",
+		row, column, width, height, nrql, title, viz, notes))
 
 	return hashcode.String(buf.String())
 }

--- a/newrelic/resource_newrelic_dashboard.go
+++ b/newrelic/resource_newrelic_dashboard.go
@@ -1,0 +1,288 @@
+package newrelic
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+	newrelic "github.com/paultyng/go-newrelic/api"
+)
+
+func stringInList(values []string) schema.SchemaValidateFunc {
+	return func(v interface{}, k string) (we []string, errors []error) {
+		value := v.(string)
+		valid := false
+		for _, v := range values {
+			if value == v {
+				valid = true
+				break
+			}
+		}
+
+		if !valid {
+			errors = append(errors, fmt.Errorf("%s is an invalid value for argument %s", value, k))
+		}
+		return
+	}
+}
+
+func resourceNewRelicDashboard() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNewRelicDashboardCreate,
+		Read:   resourceNewRelicDashboardRead,
+		Update: resourceNewRelicDashboardUpdate,
+		Delete: resourceNewRelicDashboardDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"title": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+			},
+			"icon": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "bar-chart",
+			},
+			"visibility": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "all",
+				ValidateFunc: stringInList([]string{"owner", "all"}),
+			},
+			"dashboard_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"editable": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "editable_by_all",
+				ValidateFunc: stringInList([]string{"read_only", "editable_by_owner", "editable_by_all", "all"}),
+			},
+			"widget": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MaxItems: 60,
+				Set:      resourceNewRelicDashboardWidgetsHash,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"title": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"visualization": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"width": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  1,
+						},
+						"height": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  1,
+						},
+						"row": &schema.Schema{
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"column": &schema.Schema{
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"notes": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						// TODO: Move this to a set/map?
+						"nrql": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceNewRelicDashboardWidgetsHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+
+	row := m["row"].(int)
+	column := m["column"].(int)
+
+	buf.WriteString(fmt.Sprintf("%d-%d", row, column))
+
+	return hashcode.String(buf.String())
+}
+
+func buildDashboardStruct(d *schema.ResourceData) *newrelic.Dashboard {
+	metadata := newrelic.DashboardMetadata{
+		Version: 1,
+	}
+
+	// TODO: Some of these should be terraform defaults and validated
+	dashboard := newrelic.Dashboard{
+		Title:      d.Get("title").(string),
+		Metadata:   metadata,
+		Icon:       d.Get("icon").(string),
+		Visibility: d.Get("visibility").(string),
+		Editable:   d.Get("editable").(string),
+	}
+	log.Printf("[INFO] widget schema: %+v\n", d.Get("widget"))
+
+	if w, ok := d.GetOk("widget"); ok {
+		widgets := w.(*schema.Set).List()
+		for _, widget := range widgets {
+			w := widget.(map[string]interface{})
+
+			widgetPresentation := newrelic.DashboardWidgetPresentation{
+				Title: w["title"].(string),
+				Notes: w["notes"].(string),
+			}
+
+			widgetLayout := newrelic.DashboardWidgetLayout{
+				Row:    w["row"].(int),
+				Column: w["column"].(int),
+				Width:  w["width"].(int),
+				Height: w["height"].(int),
+			}
+
+			// TODO: Support non-NRQL Widgets
+			widgetData := make([]newrelic.DashboardWidgetData, 0, 1)
+			widgetData = append(widgetData, newrelic.DashboardWidgetData{
+				NRQL: w["nrql"].(string),
+			})
+
+			dashboard.Widgets = append(dashboard.Widgets, newrelic.DashboardWidget{
+				Visualization: w["visualization"].(string),
+				Layout:        widgetLayout,
+				Presentation:  widgetPresentation,
+				Data:          widgetData,
+			})
+		}
+	}
+
+	return &dashboard
+}
+
+func readDashboardStruct(dashboard *newrelic.Dashboard, d *schema.ResourceData) error {
+	d.Set("title", dashboard.Title)
+	d.Set("icon", dashboard.Icon)
+	d.Set("visibility", dashboard.Visibility)
+	d.Set("editable", dashboard.Editable)
+	d.Set("dashboard_url", dashboard.UIURL)
+
+	widgetSet := schema.Set{
+		F: resourceNewRelicDashboardWidgetsHash,
+	}
+	for _, widget := range dashboard.Widgets {
+		values := map[string]interface{}{}
+		values["visualization"] = widget.Visualization
+		values["title"] = widget.Presentation.Title
+		values["notes"] = widget.Presentation.Notes
+		values["row"] = widget.Layout.Row
+		values["column"] = widget.Layout.Column
+		values["width"] = widget.Layout.Width
+		values["height"] = widget.Layout.Height
+
+		// TODO: Support non-NRQL Widgets
+		if len(widget.Data) > 0 {
+			values["nrql"] = widget.Data[0].NRQL
+		}
+		widgetSet.Add(values)
+	}
+	err := d.Set("widget", &widgetSet)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceNewRelicDashboardCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*newrelic.Client)
+	dashboard := buildDashboardStruct(d)
+	log.Printf("[INFO] Creating New Relic dashboard: %s", dashboard.Title)
+
+	dashboard, err := client.CreateDashboard(*dashboard)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(strconv.Itoa(dashboard.ID))
+
+	return resourceNewRelicDashboardRead(d, meta)
+}
+
+func resourceNewRelicDashboardRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*newrelic.Client)
+
+	log.Printf("[INFO] Reading New Relic dashboard %s", d.Id())
+
+	dashboardID, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return err
+	}
+
+	dashboard, err := client.GetDashboard(dashboardID)
+	if err != nil {
+		if err == newrelic.ErrNotFound {
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	return readDashboardStruct(dashboard, d)
+}
+
+func resourceNewRelicDashboardUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*newrelic.Client)
+	dashboard := buildDashboardStruct(d)
+
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return err
+	}
+
+	dashboard.ID = id
+	log.Printf("[INFO] Updating New Relic dashboard %d", id)
+
+	_, err = client.UpdateDashboard(*dashboard)
+	if err != nil {
+		return err
+	}
+
+	return resourceNewRelicDashboardRead(d, meta)
+}
+
+func resourceNewRelicDashboardDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*newrelic.Client)
+
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Deleting New Relic dashboard %v", id)
+
+	if err := client.DeleteDashboard(id); err != nil {
+		return err
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/newrelic/resource_newrelic_dashboard.go
+++ b/newrelic/resource_newrelic_dashboard.go
@@ -276,6 +276,10 @@ func resourceNewRelicDashboardDelete(d *schema.ResourceData, meta interface{}) e
 	log.Printf("[INFO] Deleting New Relic dashboard %v", id)
 
 	if err := client.DeleteDashboard(id); err != nil {
+		if err == newrelic.ErrNotFound {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 

--- a/newrelic/resource_newrelic_dashboard_test.go
+++ b/newrelic/resource_newrelic_dashboard_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 func TestAccNewRelicDashboard_Basic(t *testing.T) {
-	rName := acctest.RandString(5)
+	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+	rNameUpdated := fmt.Sprintf("%s-updated", rName)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -24,7 +25,7 @@ func TestAccNewRelicDashboard_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicDashboardExists("newrelic_dashboard.foo"),
 					resource.TestCheckResourceAttr(
-						"newrelic_dashboard.foo", "title", fmt.Sprintf("tf-test-%s", rName)),
+						"newrelic_dashboard.foo", "title", rName),
 					resource.TestCheckResourceAttr(
 						"newrelic_dashboard.foo", "editable", "editable_by_all"),
 					resource.TestCheckResourceAttr(
@@ -49,33 +50,33 @@ func TestAccNewRelicDashboard_Basic(t *testing.T) {
 			},
 			// Update dashboard title
 			resource.TestStep{
-				Config: testAccCheckNewRelicDashboardConfigUpdated(rName),
+				Config: testAccCheckNewRelicDashboardConfigUpdated(rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicDashboardExists("newrelic_dashboard.foo"),
 					resource.TestCheckResourceAttr(
-						"newrelic_dashboard.foo", "title", fmt.Sprintf("tf-test-updated-%s", rName)),
+						"newrelic_dashboard.foo", "title", rNameUpdated),
 					resource.TestCheckResourceAttr(
 						"newrelic_dashboard.foo", "widget.#", "1"),
 				),
 			},
 			// Add widget
 			resource.TestStep{
-				Config: testAccCheckNewRelicDashboardWidgetConfigAdded(rName),
+				Config: testAccCheckNewRelicDashboardWidgetConfigAdded(rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicDashboardExists("newrelic_dashboard.foo"),
 					resource.TestCheckResourceAttr(
-						"newrelic_dashboard.foo", "title", fmt.Sprintf("tf-test-updated-%s", rName)),
+						"newrelic_dashboard.foo", "title", rNameUpdated),
 					resource.TestCheckResourceAttr(
 						"newrelic_dashboard.foo", "widget.#", "2"),
 				),
 			},
 			// Update widget
 			resource.TestStep{
-				Config: testAccCheckNewRelicDashboardWidgetConfigUpdated(rName),
+				Config: testAccCheckNewRelicDashboardWidgetConfigUpdated(rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicDashboardExists("newrelic_dashboard.foo"),
 					resource.TestCheckResourceAttr(
-						"newrelic_dashboard.foo", "title", fmt.Sprintf("tf-test-updated-%s", rName)),
+						"newrelic_dashboard.foo", "title", rNameUpdated),
 					resource.TestCheckResourceAttr(
 						"newrelic_dashboard.foo", "widget.#", "2"),
 					resource.TestCheckResourceAttr(
@@ -141,19 +142,19 @@ func testAccCheckNewRelicDashboardExists(n string) resource.TestCheckFunc {
 func testAccCheckNewRelicDashboardWidgetConfigAdded(rName string) string {
 	return fmt.Sprintf(`
 resource "newrelic_dashboard" "foo" {
-  title                = "tf-test-updated-%s"
+  title                = "%s"
   widget {
     title         = "Average Transaction Duration"
-	visualization = "faceted_line_chart"
-	column		  = 1
-	row			  = 1
+    visualization = "faceted_line_chart"
+    column        = 1
+    row           = 1
     nrql          = "SELECT PERCENTILE(duration, 95) from Transaction FACET appName TIMESERIES auto"
   }
   widget {
     title         = "Page Views"
 	visualization = "faceted_line_chart"
-	column		  = 1
-	row			  = 2
+	column        = 1
+	row           = 2
     nrql          = "SELECT AVERAGE(duration) from PageView FACET appName TIMESERIES auto"
   }
 }
@@ -163,19 +164,19 @@ resource "newrelic_dashboard" "foo" {
 func testAccCheckNewRelicDashboardWidgetConfigUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "newrelic_dashboard" "foo" {
-  title                = "tf-test-updated-%s"
+  title                = "%s"
   widget {
     title         = "Average Transaction Duration"
-	visualization = "faceted_line_chart"
-	column		  = 1
-	row			  = 1
+    visualization = "faceted_line_chart"
+    column        = 1
+    row           = 1
     nrql          = "SELECT PERCENTILE(duration, 50) from Transaction FACET appName TIMESERIES auto"
   }
   widget {
     title         = "Page Views"
-	visualization = "faceted_line_chart"
-	column		  = 1
-	row			  = 2
+    visualization = "faceted_line_chart"
+    column        = 1
+    row           = 2
     nrql          = "SELECT AVERAGE(duration) from PageView FACET appName TIMESERIES auto"
   }
 }
@@ -185,12 +186,12 @@ resource "newrelic_dashboard" "foo" {
 func testAccCheckNewRelicDashboardConfigUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "newrelic_dashboard" "foo" {
-  title                = "tf-test-updated-%s"
+  title                = "%s"
   widget {
     title         = "Average Transaction Duration"
-	visualization = "faceted_line_chart"
-	column		  = 1
-	row			  = 1
+    visualization = "faceted_line_chart"
+    column        = 1
+    row           = 1
     nrql          = "SELECT AVERAGE(duration) from Transaction FACET appName TIMESERIES auto"
   }
 }
@@ -200,12 +201,12 @@ resource "newrelic_dashboard" "foo" {
 func testAccCheckNewRelicDashboardConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "newrelic_dashboard" "foo" {
-  title = "tf-test-%s"
+  title = "%s"
   widget {
     title         = "Average Transaction Duration"
-	visualization = "faceted_line_chart"
-	column		  = 1
-	row			  = 1
+    visualization = "faceted_line_chart"
+    column        = 1
+    row           = 1
     nrql          = "SELECT AVERAGE(duration) from Transaction FACET appName TIMESERIES auto"
   }
 }

--- a/newrelic/resource_newrelic_dashboard_test.go
+++ b/newrelic/resource_newrelic_dashboard_test.go
@@ -1,0 +1,69 @@
+package newrelic
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	newrelic "source.datanerd.us/csmith/go-newrelic/api"
+)
+
+func TestAccNewRelicDashboard_Basic(t *testing.T) {
+	rName := acctest.RandString(5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckNewRelicDashboardConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicDashboardExists("newrelic_dashboard.foo"),
+					resource.TestCheckResourceAttr(
+						"newrelic_dashboard.foo", "title", fmt.Sprintf("tf-test-%s", rName)),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckNewRelicDashboardExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No dashboard ID is set")
+		}
+
+		client := testAccProvider.Meta().(*newrelic.Client)
+
+		id, err := strconv.ParseInt(rs.Primary.ID, 10, 32)
+		if err != nil {
+			return err
+		}
+
+		found, err := client.GetDashboard(int(id))
+		if err != nil {
+			return err
+		}
+
+		if strconv.Itoa(found.ID) != rs.Primary.ID {
+			return fmt.Errorf("Policy not found: %v - %v", rs.Primary.ID, found)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckNewRelicDashboardConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "newrelic_dashboard" "foo" {
+  title = "tf-test-%s"
+}
+`, rName)
+}

--- a/newrelic/resource_newrelic_dashboard_test.go
+++ b/newrelic/resource_newrelic_dashboard_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	newrelic "source.datanerd.us/csmith/go-newrelic/api"
+	newrelic "github.com/paultyng/go-newrelic/api"
 )
 
 func TestAccNewRelicDashboard_Basic(t *testing.T) {

--- a/newrelic/resource_newrelic_dashboard_test.go
+++ b/newrelic/resource_newrelic_dashboard_test.go
@@ -34,17 +34,17 @@ func TestAccNewRelicDashboard_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"newrelic_dashboard.foo", "widget.#", "1"),
 					resource.TestCheckResourceAttr(
-						"newrelic_dashboard.foo", "widget.2870742112.title", "Average Transaction Duration"),
+						"newrelic_dashboard.foo", "widget.754238675.title", "Average Transaction Duration"),
 					resource.TestCheckResourceAttr(
-						"newrelic_dashboard.foo", "widget.2870742112.height", "1"),
+						"newrelic_dashboard.foo", "widget.754238675.height", "1"),
 					resource.TestCheckResourceAttr(
-						"newrelic_dashboard.foo", "widget.2870742112.width", "1"),
+						"newrelic_dashboard.foo", "widget.754238675.width", "1"),
 					resource.TestCheckResourceAttr(
-						"newrelic_dashboard.foo", "widget.2870742112.row", "1"),
+						"newrelic_dashboard.foo", "widget.754238675.row", "1"),
 					resource.TestCheckResourceAttr(
-						"newrelic_dashboard.foo", "widget.2870742112.column", "1"),
+						"newrelic_dashboard.foo", "widget.754238675.column", "1"),
 					resource.TestCheckResourceAttr(
-						"newrelic_dashboard.foo", "widget.2870742112.visualization", "faceted_line_chart"),
+						"newrelic_dashboard.foo", "widget.754238675.visualization", "faceted_line_chart"),
 				),
 			},
 			// Update dashboard title
@@ -60,6 +60,17 @@ func TestAccNewRelicDashboard_Basic(t *testing.T) {
 			},
 			// Add widget
 			resource.TestStep{
+				Config: testAccCheckNewRelicDashboardWidgetConfigAdded(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicDashboardExists("newrelic_dashboard.foo"),
+					resource.TestCheckResourceAttr(
+						"newrelic_dashboard.foo", "title", fmt.Sprintf("tf-test-updated-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"newrelic_dashboard.foo", "widget.#", "2"),
+				),
+			},
+			// Update widget
+			resource.TestStep{
 				Config: testAccCheckNewRelicDashboardWidgetConfigUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicDashboardExists("newrelic_dashboard.foo"),
@@ -67,6 +78,8 @@ func TestAccNewRelicDashboard_Basic(t *testing.T) {
 						"newrelic_dashboard.foo", "title", fmt.Sprintf("tf-test-updated-%s", rName)),
 					resource.TestCheckResourceAttr(
 						"newrelic_dashboard.foo", "widget.#", "2"),
+					resource.TestCheckResourceAttr(
+						"newrelic_dashboard.foo", "widget.3380029573.nrql", "SELECT PERCENTILE(duration, 50) from Transaction FACET appName TIMESERIES auto"),
 				),
 			},
 		},
@@ -125,7 +138,7 @@ func testAccCheckNewRelicDashboardExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckNewRelicDashboardWidgetConfigUpdated(rName string) string {
+func testAccCheckNewRelicDashboardWidgetConfigAdded(rName string) string {
 	return fmt.Sprintf(`
 resource "newrelic_dashboard" "foo" {
   title                = "tf-test-updated-%s"
@@ -135,6 +148,28 @@ resource "newrelic_dashboard" "foo" {
 	column		  = 1
 	row			  = 1
     nrql          = "SELECT PERCENTILE(duration, 95) from Transaction FACET appName TIMESERIES auto"
+  }
+  widget {
+    title         = "Page Views"
+	visualization = "faceted_line_chart"
+	column		  = 1
+	row			  = 2
+    nrql          = "SELECT AVERAGE(duration) from PageView FACET appName TIMESERIES auto"
+  }
+}
+`, rName)
+}
+
+func testAccCheckNewRelicDashboardWidgetConfigUpdated(rName string) string {
+	return fmt.Sprintf(`
+resource "newrelic_dashboard" "foo" {
+  title                = "tf-test-updated-%s"
+  widget {
+    title         = "Average Transaction Duration"
+	visualization = "faceted_line_chart"
+	column		  = 1
+	row			  = 1
+    nrql          = "SELECT PERCENTILE(duration, 50) from Transaction FACET appName TIMESERIES auto"
   }
   widget {
     title         = "Page Views"

--- a/newrelic/resource_newrelic_dashboard_test.go
+++ b/newrelic/resource_newrelic_dashboard_test.go
@@ -16,18 +16,83 @@ func TestAccNewRelicDashboard_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNewRelicAlertPolicyDestroy,
+		CheckDestroy: testAccCheckNewRelicDashboardDestroy,
 		Steps: []resource.TestStep{
+			// Check exists
 			resource.TestStep{
 				Config: testAccCheckNewRelicDashboardConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicDashboardExists("newrelic_dashboard.foo"),
 					resource.TestCheckResourceAttr(
 						"newrelic_dashboard.foo", "title", fmt.Sprintf("tf-test-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"newrelic_dashboard.foo", "editable", "editable_by_all"),
+					resource.TestCheckResourceAttr(
+						"newrelic_dashboard.foo", "icon", "bar-chart"),
+					resource.TestCheckResourceAttr(
+						"newrelic_dashboard.foo", "visibility", "all"),
+					resource.TestCheckResourceAttr(
+						"newrelic_dashboard.foo", "widget.#", "1"),
+					resource.TestCheckResourceAttr(
+						"newrelic_dashboard.foo", "widget.2870742112.title", "Average Transaction Duration"),
+					resource.TestCheckResourceAttr(
+						"newrelic_dashboard.foo", "widget.2870742112.height", "1"),
+					resource.TestCheckResourceAttr(
+						"newrelic_dashboard.foo", "widget.2870742112.width", "1"),
+					resource.TestCheckResourceAttr(
+						"newrelic_dashboard.foo", "widget.2870742112.row", "1"),
+					resource.TestCheckResourceAttr(
+						"newrelic_dashboard.foo", "widget.2870742112.column", "1"),
+					resource.TestCheckResourceAttr(
+						"newrelic_dashboard.foo", "widget.2870742112.visualization", "faceted_line_chart"),
+				),
+			},
+			// Update dashboard title
+			resource.TestStep{
+				Config: testAccCheckNewRelicDashboardConfigUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicDashboardExists("newrelic_dashboard.foo"),
+					resource.TestCheckResourceAttr(
+						"newrelic_dashboard.foo", "title", fmt.Sprintf("tf-test-updated-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"newrelic_dashboard.foo", "widget.#", "1"),
+				),
+			},
+			// Add widget
+			resource.TestStep{
+				Config: testAccCheckNewRelicDashboardWidgetConfigUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicDashboardExists("newrelic_dashboard.foo"),
+					resource.TestCheckResourceAttr(
+						"newrelic_dashboard.foo", "title", fmt.Sprintf("tf-test-updated-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"newrelic_dashboard.foo", "widget.#", "2"),
 				),
 			},
 		},
 	})
+}
+
+func testAccCheckNewRelicDashboardDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*newrelic.Client)
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "newrelic_dashboard" {
+			continue
+		}
+
+		id, err := strconv.ParseInt(r.Primary.ID, 10, 32)
+		if err != nil {
+			return err
+		}
+
+		_, err = client.GetDashboard(int(id))
+
+		if err == nil {
+			return fmt.Errorf("Dashboard still exists")
+		}
+
+	}
+	return nil
 }
 
 func testAccCheckNewRelicDashboardExists(n string) resource.TestCheckFunc {
@@ -53,17 +118,61 @@ func testAccCheckNewRelicDashboardExists(n string) resource.TestCheckFunc {
 		}
 
 		if strconv.Itoa(found.ID) != rs.Primary.ID {
-			return fmt.Errorf("Policy not found: %v - %v", rs.Primary.ID, found)
+			return fmt.Errorf("Dashboard not found: %v - %v", rs.Primary.ID, found)
 		}
 
 		return nil
 	}
 }
 
+func testAccCheckNewRelicDashboardWidgetConfigUpdated(rName string) string {
+	return fmt.Sprintf(`
+resource "newrelic_dashboard" "foo" {
+  title                = "tf-test-updated-%s"
+  widget {
+    title         = "Average Transaction Duration"
+	visualization = "faceted_line_chart"
+	column		  = 1
+	row			  = 1
+    nrql          = "SELECT PERCENTILE(duration, 95) from Transaction FACET appName TIMESERIES auto"
+  }
+  widget {
+    title         = "Page Views"
+	visualization = "faceted_line_chart"
+	column		  = 1
+	row			  = 2
+    nrql          = "SELECT AVERAGE(duration) from PageView FACET appName TIMESERIES auto"
+  }
+}
+`, rName)
+}
+
+func testAccCheckNewRelicDashboardConfigUpdated(rName string) string {
+	return fmt.Sprintf(`
+resource "newrelic_dashboard" "foo" {
+  title                = "tf-test-updated-%s"
+  widget {
+    title         = "Average Transaction Duration"
+	visualization = "faceted_line_chart"
+	column		  = 1
+	row			  = 1
+    nrql          = "SELECT AVERAGE(duration) from Transaction FACET appName TIMESERIES auto"
+  }
+}
+`, rName)
+}
+
 func testAccCheckNewRelicDashboardConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "newrelic_dashboard" "foo" {
   title = "tf-test-%s"
+  widget {
+    title         = "Average Transaction Duration"
+	visualization = "faceted_line_chart"
+	column		  = 1
+	row			  = 1
+    nrql          = "SELECT AVERAGE(duration) from Transaction FACET appName TIMESERIES auto"
+  }
 }
 `, rName)
 }

--- a/vendor/github.com/paultyng/go-newrelic/LICENSE
+++ b/vendor/github.com/paultyng/go-newrelic/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2017 Paul Tyng
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vendor/github.com/paultyng/go-newrelic/api/dashboards.go
+++ b/vendor/github.com/paultyng/go-newrelic/api/dashboards.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"fmt"
+	"net/url"
+)
+
+func (c *Client) queryDashboards() ([]Dashboard, error) {
+	dashboards := []Dashboard{}
+	reqURL, err := url.Parse("/dashboards.json")
+
+	if err != nil {
+		return nil, err
+	}
+	nextPath := reqURL.String()
+
+	for nextPath != "" {
+		resp := struct {
+			Dashboards []Dashboard `json:"dashboards,omitempty"`
+		}{}
+
+		nextPath, err = c.Do("GET", nextPath, nil, &resp)
+		if err != nil {
+			return nil, err
+		}
+
+		dashboards = append(dashboards, resp.Dashboards...)
+	}
+	return dashboards, nil
+}
+
+// GetDashboard returns a specific dashboard for the account.
+func (c *Client) GetDashboard(id int) (*Dashboard, error) {
+	reqURL, err := url.Parse(fmt.Sprintf("/dashboards/%v.json", id))
+
+	if err != nil {
+		return nil, err
+	}
+
+	resp := struct {
+		Dashboard Dashboard `json:"dashboard,omitempty"`
+	}{}
+
+	_, err = c.Do("GET", reqURL.String(), nil, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp.Dashboard, nil
+}
+
+// ListDashboards returns all dashboards  for the account.
+func (c *Client) ListDashboards() ([]Dashboard, error) {
+	return c.queryDashboards()
+}
+
+// CreateDashboard creates dashboard given the passed configuration.
+func (c *Client) CreateDashboard(dashboard Dashboard) (*Dashboard, error) {
+	req := struct {
+		Dashboard Dashboard `json:"dashboard"`
+	}{
+		Dashboard: dashboard,
+	}
+
+	resp := struct {
+		Dashboard Dashboard `json:"dashboard,omitempty"`
+	}{}
+
+	u := &url.URL{Path: "/dashboards.json"}
+	_, err := c.Do("POST", u.String(), req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp.Dashboard, nil
+}
+
+// UpdateDashboard updates a dashboard given the passed configuration
+func (c *Client) UpdateDashboard(dashboard Dashboard) (*Dashboard, error) {
+	id := dashboard.ID
+
+	req := struct {
+		Dashboard Dashboard `json:"dashboard"`
+	}{
+		Dashboard: dashboard,
+	}
+
+	resp := struct {
+		Dashboard Dashboard `json:"dashboard,omitempty"`
+	}{}
+
+	u := &url.URL{Path: fmt.Sprintf("/dashboards/%v.json", id)}
+	_, err := c.Do("PUT", u.String(), req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp.Dashboard, nil
+}
+
+// DeleteDashboard deletes an existing dashboard given the passed configuration
+func (c *Client) DeleteDashboard(id int) error {
+	u := &url.URL{Path: fmt.Sprintf("/dashboards/%v.json", id)}
+	_, err := c.Do("DELETE", u.String(), nil, nil)
+	return err
+}

--- a/vendor/github.com/paultyng/go-newrelic/api/key_transactions.go
+++ b/vendor/github.com/paultyng/go-newrelic/api/key_transactions.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"fmt"
+	"net/url"
+)
+
+func (c *Client) queryKeyTransactions() ([]KeyTransaction, error) {
+	transactions := []KeyTransaction{}
+
+	reqURL, err := url.Parse("/key_transactions.json")
+	if err != nil {
+		return nil, err
+	}
+
+	nextPath := reqURL.String()
+
+	for nextPath != "" {
+		resp := struct {
+			Transactions []KeyTransaction `json:"key_transactions,omitempty"`
+		}{}
+
+		nextPath, err = c.Do("GET", nextPath, nil, &resp)
+		if err != nil {
+			return nil, err
+		}
+
+		transactions = append(transactions, resp.Transactions...)
+	}
+
+	return transactions, nil
+}
+
+// GetKeyTransaction returns a specific key transaction by ID.
+func (c *Client) GetKeyTransaction(id int) (*KeyTransaction, error) {
+	reqURL, err := url.Parse(fmt.Sprintf("/key_transactions/%v.json", id))
+	if err != nil {
+		return nil, err
+	}
+
+	resp := struct {
+		Transaction KeyTransaction `json:"key_transaction,omitempty"`
+	}{}
+
+	_, err = c.Do("GET", reqURL.String(), nil, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp.Transaction, nil
+}
+
+// ListKeyTransactions returns all key transactions for the account.
+func (c *Client) ListKeyTransactions() ([]KeyTransaction, error) {
+	return c.queryKeyTransactions()
+}

--- a/vendor/github.com/paultyng/go-newrelic/api/types.go
+++ b/vendor/github.com/paultyng/go-newrelic/api/types.go
@@ -49,17 +49,19 @@ type AlertConditionTerm struct {
 // TODO: custom unmarshal entities to ints?
 // TODO: handle unmarshaling .75 for float (not just 0.75)
 type AlertCondition struct {
-	PolicyID    int                       `json:"-"`
-	ID          int                       `json:"id,omitempty"`
-	Type        string                    `json:"type,omitempty"`
-	Name        string                    `json:"name,omitempty"`
-	Enabled     bool                      `json:"enabled,omitempty"`
-	Entities    []string                  `json:"entities,omitempty"`
-	Metric      string                    `json:"metric,omitempty"`
-	RunbookURL  string                    `json:"runbook_url,omitempty"`
-	Terms       []AlertConditionTerm      `json:"terms,omitempty"`
-	UserDefined AlertConditionUserDefined `json:"user_defined,omitempty"`
-	Scope       string                    `json:"condition_scope,omitempty"`
+	PolicyID            int                       `json:"-"`
+	ID                  int                       `json:"id,omitempty"`
+	Type                string                    `json:"type,omitempty"`
+	Name                string                    `json:"name,omitempty"`
+	Enabled             bool                      `json:"enabled,omitempty"`
+	Entities            []string                  `json:"entities,omitempty"`
+	Metric              string                    `json:"metric,omitempty"`
+	RunbookURL          string                    `json:"runbook_url,omitempty"`
+	Terms               []AlertConditionTerm      `json:"terms,omitempty"`
+	UserDefined         AlertConditionUserDefined `json:"user_defined,omitempty"`
+	Scope               string                    `json:"condition_scope,omitempty"`
+	GCMetric            string                    `json:"gc_metric,omitempty"`
+	ViolationCloseTimer int                       `json:"violation_close_timer,omitempty"`
 }
 
 // AlertNrqlQuery represents a NRQL query to use with a NRQL alert condition
@@ -232,4 +234,66 @@ type Component struct {
 type ComponentMetric struct {
 	Name   string   `json:"name,omitempty"`
 	Values []string `json:"values"`
+}
+
+// KeyTransaction represents information about a New Relic key transaction.
+type KeyTransaction struct {
+	ID              int                       `json:"id,omitempty"`
+	Name            string                    `json:"name,omitempty"`
+	TransactionName string                    `json:"transaction_name,omitempty"`
+	HealthStatus    string                    `json:"health_status,omitempty"`
+	Reporting       bool                      `json:"reporting,omitempty"`
+	LastReportedAt  string                    `json:"last_reported_at,omitempty"`
+	Summary         ApplicationSummary        `json:"application_summary,omitempty"`
+	EndUserSummary  ApplicationEndUserSummary `json:"end_user_summary,omitempty"`
+	Links           ApplicationLinks          `json:"links,omitempty"`
+}
+
+// Dashboard represents information about a New Relic dashboard.
+type Dashboard struct {
+	ID         int               `json:"id"`
+	Title      string            `json:"title,omitempty"`
+	Icon       string            `json:"icon,omitempty"`
+	CreatedAt  string            `json:"created_at,omitempty"`
+	UpdatedAt  string            `json:"updated_at,omitempty"`
+	Visibility string            `json:"visibility,omitempty"`
+	Editable   string            `json:"editable,omitempty"`
+	UIURL      string            `json:"ui_url,omitempty"`
+	APIRL      string            `json:"api_url,omitempty"`
+	OwnerEmail string            `json:"owner_email,omitempty"`
+	Metadata   DashboardMetadata `json:"metadata"`
+	Widgets    []DashboardWidget `json:"widgets,omitempty"`
+}
+
+// DashboardMetadata represents metadata about the dashboard (like version)
+type DashboardMetadata struct {
+	Version int `json:"version"`
+}
+
+// DashboardWidget represents a widget in a dashboard.
+type DashboardWidget struct {
+	Visualization string                      `json:"visualization,omitempty"`
+	AccountID     int                         `json:"account_id,omitempty"`
+	Data          []DashboardWidgetData       `json:"data,omitempty"`
+	Presentation  DashboardWidgetPresentation `json:"presentation,omitempty"`
+	Layout        DashboardWidgetLayout       `json:"layout,omitempty"`
+}
+
+// DashboardWidgetData represents the data backing a dashboard widget.
+type DashboardWidgetData struct {
+	NRQL string `json:"nrql,omitempty"`
+}
+
+// DashboardWidgetPresentation representations the visual presentation of a dashboard widget
+type DashboardWidgetPresentation struct {
+	Title string `json:"title,omitempty"`
+	Notes string `json:"notes,omitempty"`
+}
+
+// DashboardWidgetLayout represents the layout of a widget in a dashboard.
+type DashboardWidgetLayout struct {
+	Width  int `json:"width"`
+	Height int `json:"height"`
+	Row    int `json:"row"`
+	Column int `json:"column"`
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -604,10 +604,10 @@
 			"revisionTime": "2016-11-16T22:44:47Z"
 		},
 		{
-			"checksumSHA1": "7DeYeNvvsiruxTa0EeD/pHjAUCQ=",
+			"checksumSHA1": "8UonU0IfV3BjknE1g2mhZ4rTwBg=",
 			"path": "github.com/paultyng/go-newrelic/api",
-			"revision": "c788556a307ec84b9b11087c27c62b2eb652ba17",
-			"revisionTime": "2017-07-11T17:07:03Z"
+			"revision": "960e8b39399fe02c2bb58ce0498abec2564fdd1c",
+			"revisionTime": "2018-01-24T20:26:26Z"
 		},
 		{
 			"checksumSHA1": "u5s2PZ7fzCOqQX7bVPf9IJ+qNLQ=",

--- a/website/docs/r/dashboard.html.markdown
+++ b/website/docs/r/dashboard.html.markdown
@@ -1,0 +1,61 @@
+---
+layout: "newrelic"
+page_title: "New Relic: newrelic_dashboard"
+sidebar_current: "docs-newrelic-resource-dashboard"
+description: |-
+  Create and manage dashboards in New Relic.
+---
+
+# newrelic\_dashboard
+
+## Example Usage
+
+```hcl
+resource "newrelic_dashboard" "exampledash" {
+  title = "New Relic Terraform Example"
+
+  widget {
+    title         = "Average Transaction Duration"
+    row           = 1
+    column        = 1
+    width         = 2
+    visualization = "faceted_line_chart"
+    nrql          = "SELECT AVERAGE(duration) from Transaction FACET appName TIMESERIES auto"
+  }
+
+  widget {
+    title         = "Page Views"
+    row           = 1
+    column        = 3
+    visualization = "billboard"
+    nrql          = "SELECT count(*) FROM PageView SINCE 1 week ago"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+  * `title` - (Required) The title of the dashboard.
+  * `icon` - (Optional) The icon for the dashboard.  Defaults to `bar-chart`.
+  * `visibility` - (Optional) Who can see the dashboard in an account. Must be `owner` or `all`. Defaults to `all`.
+  * `widget` - (Optional) A widget that describes a visualization. See [Widgets](#widgets) below for details.
+  * `editable` - (Optional) Who can edit the dashboard in an account. Must be `read_only`, `editable_by_owner`, `editable_by_all`, or `all`. Defaults to `editable_by_all`.
+
+## Widgets
+
+The `widget` mapping supports the following arguments:
+
+  * `title` - (Required) A title for the widget.
+  * `visualization` - (Required) How the widget visualizes data.
+  * `row` - (Optional) Row position of widget from top left, starting at `1`. Defaults to `1`.
+  * `column` - (Optional) Column position of widget from top left, starting at `1`.  Defaults to `1`.
+  * `notes` - (Optional) Description of the widget.
+  * `nrql` - (Optional) Valid NRQL query string. See [Writing NRQL Queries](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/using-nrql/introduction-nrql) for help.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+  * `id` - The ID of the dashboard.

--- a/website/docs/r/dashboard.html.markdown
+++ b/website/docs/r/dashboard.html.markdown
@@ -49,8 +49,10 @@ The `widget` mapping supports the following arguments:
 
   * `title` - (Required) A title for the widget.
   * `visualization` - (Required) How the widget visualizes data.
-  * `row` - (Optional) Row position of widget from top left, starting at `1`. Defaults to `1`.
-  * `column` - (Optional) Column position of widget from top left, starting at `1`.  Defaults to `1`.
+  * `row` - (Required) Row position of widget from top left, starting at `1`.
+  * `column` - (Required) Column position of widget from top left, starting at `1`.
+  * `width` - (Optional) Width of the widget. Defaults to `1`.
+  * `height` - (Optional) Height of the widget. Defaults to `1`.
   * `notes` - (Optional) Description of the widget.
   * `nrql` - (Optional) Valid NRQL query string. See [Writing NRQL Queries](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/using-nrql/introduction-nrql) for help.
 

--- a/website/newrelic.erb
+++ b/website/newrelic.erb
@@ -37,6 +37,9 @@
                 <li<%= sidebar_current("docs-newrelic-resource-nrql-alert-condition") %>>
                     <a href="/docs/providers/newrelic/r/nrql_alert_condition.html">newrelic_nrql_alert_condition</a>
                 </li>
+                <li<%= sidebar_current("docs-newrelic-resource-dashboard") %>>
+                    <a href="/docs/providers/newrelic/r/dashboard.html">newrelic_dashboard</a>
+                </li>
             </ul>
         </li>
     </ul>


### PR DESCRIPTION
Depends on: https://github.com/paultyng/go-newrelic/pull/14

Adds support for the new Dashboard API, this will let people write and manage dashboards as code.

still needs:
- [x] [acceptance test](https://github.com/hashicorp/terraform/blob/master/.github/CONTRIBUTING.md#writing-acceptance-tests) coverage
- [x] add website docs

Docs: https://docs.newrelic.com/docs/insights/insights-api/manage-dashboards/insights-dashboard-api
Announcement: https://blog.newrelic.com/2018/01/08/insights-dashboard-api/