### PR TITLE
test: Ignore tests which are commented out

### DIFF
--- a/newrelic/resource_newrelic_alert_condition_test.go
+++ b/newrelic/resource_newrelic_alert_condition_test.go
@@ -108,7 +108,7 @@ func TestAccNewRelicAlertCondition_ZeroThreshold(t *testing.T) {
 	})
 }
 
-// TODO: func TestAccNewRelicAlertCondition_Multi(t *testing.T) {
+// TODO: func_ TestAccNewRelicAlertCondition_Multi(t *testing.T) {
 
 func testAccCheckNewRelicAlertConditionDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*newrelic.Client)

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -81,7 +81,7 @@ func TestAccNewRelicNrqlAlertCondition_Basic(t *testing.T) {
 	})
 }
 
-// TODO: func TestAccNewRelicNrqlAlertCondition_Multi(t *testing.T) {
+// TODO: func_ TestAccNewRelicNrqlAlertCondition_Multi(t *testing.T) {
 
 func testAccCheckNewRelicNrqlAlertConditionDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*newrelic.Client)


### PR DESCRIPTION
This is to make tests in TeamCity work. It looks odd, but we have a script which `grep`s for test names to run them in parallel. It's not ideal and it was created long time before `go test -list` was a thing. We plan to fix it eventually, so such workarounds aren't necessary.

For now this is the easiest way to get it working again 🤷‍♂️ 