### PR TITLE
Add support for data alert channel

### DIFF
--- a/newrelic/data_source_newrelic_alert_channel.go
+++ b/newrelic/data_source_newrelic_alert_channel.go
@@ -1,0 +1,65 @@
+package newrelic
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	newrelic "github.com/paultyng/go-newrelic/v4/api"
+)
+
+func dataSourceNewRelicAlertChannel() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNewRelicAlertChannelRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"policy_ids": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceNewRelicAlertChannelRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ProviderConfig).Client
+
+	log.Printf("[INFO] Reading New Relic Alert Channels")
+
+	channels, err := client.ListAlertChannels()
+	if err != nil {
+		return err
+	}
+
+	var channel *newrelic.AlertChannel
+	name := d.Get("name").(string)
+
+	for _, c := range channels {
+		if strings.Contains(strings.ToLower(c.Name), strings.ToLower(name)) {
+			channel = &c
+			break
+		}
+	}
+
+	if channel == nil {
+		return fmt.Errorf("The name '%s' does not match any New Relic alert channel.", name)
+	}
+
+	d.SetId(strconv.Itoa(channel.ID))
+	d.Set("name", channel.Name)
+	d.Set("type", channel.Type)
+	d.Set("policy_ids", channel.Links.PolicyIDs)
+
+	return nil
+}

--- a/newrelic/data_source_newrelic_alert_channel_test.go
+++ b/newrelic/data_source_newrelic_alert_channel_test.go
@@ -1,0 +1,62 @@
+package newrelic
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccNewRelicAlertChannelDataSource_Basic(t *testing.T) {
+	rName := acctest.RandString(5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNewRelicAlertChannelDataSourceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNewRelicAlertChannel("data.newrelic_alert_channel.channel"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNewRelicAlertChannel(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		if a["id"] == "" {
+			return fmt.Errorf("Expected to get an alert channel from New Relic")
+		}
+
+		if strings.Contains(strings.ToLower(testAccExpectedAlertChannelName), strings.ToLower(a["name"])) {
+			return fmt.Errorf("Expected the alert channel name to be: %s, but got: %s", testAccExpectedAlertChannelName, a["name"])
+		}
+
+		return nil
+	}
+}
+
+func testAccNewRelicAlertChannelDataSourceConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "newrelic_alert_channel" "foo" {
+	name = "tf-test-%s"
+	type = "email"
+
+	configuration = {
+		recipients = "terraform-acctest+foo@hashicorp.com"
+		include_json_attachment = "1"
+	}
+}
+
+data "newrelic_alert_channel" "channel" {
+	name = "${newrelic_alert_channel.foo.name}"
+}
+`, rName)
+}

--- a/newrelic/provider.go
+++ b/newrelic/provider.go
@@ -31,6 +31,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"newrelic_alert_channel":      dataSourceNewRelicAlertChannel(),
 			"newrelic_application":        dataSourceNewRelicApplication(),
 			"newrelic_key_transaction":    dataSourceNewRelicKeyTransaction(),
 			"newrelic_synthetics_monitor": dataSourceNewRelicSyntheticsMonitor(),

--- a/newrelic/provider_test.go
+++ b/newrelic/provider_test.go
@@ -13,12 +13,14 @@ import (
 )
 
 var (
-	testAccExpectedApplicationName string
-	testAccProviders               map[string]terraform.ResourceProvider
-	testAccProvider                *schema.Provider
+	testAccExpectedAlertChannelName string
+	testAccExpectedApplicationName  string
+	testAccProviders                map[string]terraform.ResourceProvider
+	testAccProvider                 *schema.Provider
 )
 
 func init() {
+	testAccExpectedAlertChannelName = fmt.Sprintf("%s tf-test@example.com", acctest.RandString(5))
 	testAccExpectedApplicationName = fmt.Sprintf("tf_test_%s", acctest.RandString(10))
 	testAccProvider = Provider().(*schema.Provider)
 	testAccProviders = map[string]terraform.ResourceProvider{

--- a/website/docs/d/alert_channel.html.markdown
+++ b/website/docs/d/alert_channel.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "newrelic"
+page_title: "New Relic: newrelic_alert_channel"
+sidebar_current: "docs-newrelic-datasource-alert-channel"
+description: |-
+  Looks up the information about an alert channel in New Relic.
+---
+
+# newrelic\_alert\_channel
+
+Use this data source to get information about an specific alert channel in New Relic which already exists (e.g newrelic user).
+
+## Example Usage
+
+```hcl
+data "newrelic_alert_channel" "foo" {
+  name = "foo@example.com"
+}
+
+resource "newrelic_alert_policy" "foo" {
+  name = "foo"
+}
+
+resource "newrelic_alert_policy_channel" "foo" {
+  policy_id  = "${newrelic_alert_policy.foo.id}"
+  channel_id = "${newrelic_alert_channel.foo.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the alert channel in New Relic.
+
+## Attributes Reference
+* `id` - The ID of the alert channel.
+* `type` - Alert channel type, either: `campfire`, `email`, `hipchat`, `opsgenie`, `pagerduty`, `slack`, `victorops`, or `webhook`..
+* `policy_ids` - A list of policy IDs associated with the alert channel.

--- a/website/newrelic.erb
+++ b/website/newrelic.erb
@@ -13,6 +13,9 @@
         <li<%= sidebar_current("docs-newrelic-datasource") %>>
             <a href="#">Data Sources</a>
             <ul class="nav nav-visible">
+                <li<%= sidebar_current("docs-newrelic-datasource-alert-channel") %>>
+                    <a href="/docs/providers/newrelic/d/alert_channel.html">newrelic_alert_channel</a>
+                </li>
                 <li<%= sidebar_current("docs-newrelic-datasource-application") %>>
                     <a href="/docs/providers/newrelic/d/application.html">newrelic_application</a>
                 </li>


### PR DESCRIPTION
This Pull request add support for retrieving existing newrelic alert channel and re-using the id by associating it to an alert policy channel.

This becomes useful when associating an alert policy to newrelic users instead of creating an email channel or re-using an existing channel (e.g slack) in another policy.

- [x] basic test
- [x] website docs