### PR TITLE
newrelic_alert_policy int64 bug

### DIFF
--- a/newrelic/resource_newrelic_alert_policy.go
+++ b/newrelic/resource_newrelic_alert_policy.go
@@ -1,13 +1,25 @@
 package newrelic
 
 import (
+	"fmt"
 	"log"
 	"strconv"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	newrelic "github.com/paultyng/go-newrelic/api"
 )
+
+// https://github.com/hashicorp/terraform/blob/master/helper/validation/validation.go#L263
+// ValidateRFC3339TimeString is a ValidateFunc that ensures a string parses
+// as time.RFC3339 format
+func validateRFC3339TimeString(v interface{}, k string) (ws []string, errors []error) {
+	if _, err := time.Parse(time.RFC3339, v.(string)); err != nil {
+		errors = append(errors, fmt.Errorf("%q: invalid RFC3339 timestamp", k))
+	}
+	return
+}
 
 func resourceNewRelicAlertPolicy() *schema.Resource {
 	return &schema.Resource{
@@ -32,12 +44,14 @@ func resourceNewRelicAlertPolicy() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"PER_POLICY", "PER_CONDITION", "PER_CONDITION_AND_TARGET"}, false),
 			},
 			"created_at": {
-				Type:     schema.TypeInt,
-				Computed: true,
+				Type:         schema.TypeString,
+				Computed:     true,
+				ValidateFunc: validateRFC3339TimeString,
 			},
 			"updated_at": {
-				Type:     schema.TypeInt,
-				Computed: true,
+				Type:         schema.TypeString,
+				Computed:     true,
+				ValidateFunc: validateRFC3339TimeString,
 			},
 		},
 	}
@@ -71,6 +85,14 @@ func resourceNewRelicAlertPolicyCreate(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
+func unixMillis(msec int64) time.Time {
+	sec := int64(msec / 1000)
+	nsec := int64((msec - (sec * 1000)) * 1000000)
+	// Note: this will default to local time
+	created := time.Unix(sec, nsec)
+	return created
+}
+
 func resourceNewRelicAlertPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ProviderConfig).Client
 
@@ -91,10 +113,16 @@ func resourceNewRelicAlertPolicyRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
+	// New Relic provides created_at and updated_at as millisecond unix timestamps
+	// https://www.terraform.io/docs/extend/schemas/schema-types.html#date-amp-time-data
+	// "TypeString is also used for date/time data, the preferred format is RFC 3339."
+	created := unixMillis(policy.CreatedAt).Format(time.RFC3339)
+	updated := unixMillis(policy.UpdatedAt).Format(time.RFC3339)
+
 	d.Set("name", policy.Name)
 	d.Set("incident_preference", policy.IncidentPreference)
-	d.Set("created_at", policy.CreatedAt)
-	d.Set("updated_at", policy.UpdatedAt)
+	d.Set("created_at", created)
+	d.Set("updated_at", updated)
 
 	return nil
 }

--- a/newrelic/resource_newrelic_alert_policy.go
+++ b/newrelic/resource_newrelic_alert_policy.go
@@ -1,7 +1,6 @@
 package newrelic
 
 import (
-	"fmt"
 	"log"
 	"strconv"
 	"time"
@@ -10,16 +9,6 @@ import (
 	"github.com/hashicorp/terraform/helper/validation"
 	newrelic "github.com/paultyng/go-newrelic/api"
 )
-
-// https://github.com/hashicorp/terraform/blob/master/helper/validation/validation.go#L263
-// ValidateRFC3339TimeString is a ValidateFunc that ensures a string parses
-// as time.RFC3339 format
-func validateRFC3339TimeString(v interface{}, k string) (ws []string, errors []error) {
-	if _, err := time.Parse(time.RFC3339, v.(string)); err != nil {
-		errors = append(errors, fmt.Errorf("%q: invalid RFC3339 timestamp", k))
-	}
-	return
-}
 
 func resourceNewRelicAlertPolicy() *schema.Resource {
 	return &schema.Resource{
@@ -44,14 +33,12 @@ func resourceNewRelicAlertPolicy() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"PER_POLICY", "PER_CONDITION", "PER_CONDITION_AND_TARGET"}, false),
 			},
 			"created_at": {
-				Type:         schema.TypeString,
-				Computed:     true,
-				ValidateFunc: validateRFC3339TimeString,
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"updated_at": {
-				Type:         schema.TypeString,
-				Computed:     true,
-				ValidateFunc: validateRFC3339TimeString,
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}

--- a/vendor/github.com/paultyng/go-newrelic/api/types.go
+++ b/vendor/github.com/paultyng/go-newrelic/api/types.go
@@ -26,8 +26,8 @@ type AlertPolicy struct {
 	ID                 int    `json:"id,omitempty"`
 	IncidentPreference string `json:"incident_preference,omitempty"`
 	Name               string `json:"name,omitempty"`
-	CreatedAt          int    `json:"created_at,omitempty"`
-	UpdatedAt          int    `json:"updated_at,omitempty"`
+	CreatedAt          int64  `json:"created_at,omitempty"`
+	UpdatedAt          int64  `json:"updated_at,omitempty"`
 }
 
 // AlertConditionUserDefined represents user defined metrics for the New Relic alert condition.


### PR DESCRIPTION
### Terraform Version
Terraform v0.11.8

### Affected Resource(s)
- newrelic_alert_policy

### Terraform Configuration Files
```hcl
resource "newrelic_alert_policy" "example" {
  name = "example-policy"
}
output "id" {
  value = "${newrelic_alert_policy.example.id}"
}
output "created_at" {
  value = "${newrelic_alert_policy.example.created_at}"
}
output "updated_at" {
  value = "${newrelic_alert_policy.example.updated_at}"
}
```

### Debug Output
```
Error: Error applying plan:
1 error(s) occurred:
* newrelic_alert_policy.example: 1 error(s) occurred:
* newrelic_alert_policy.example: json: cannot unmarshal number 1536617863733 into Go struct field AlertPolicy.created_at of type int
```

### Expected Behavior
The after creating the alert policy, the `created_at` and `updated_at` outputs should contain the date & time for those properties.

### Actual Behavior
The newrelic_alert_policy is created, but when the plugin then tries to then get the info for the resource from the New Relic API, it fails to deserialize the json response: 
https://rpm.newrelic.com/api/explore/alerts_policies/list
```json
{
  "policy": {
    "id": "integer",
    "incident_preference": "string",
    "name": "string",
    "created_at": "integer",
    "updated_at": "integer"
  }
}
```

### Steps to Reproduce
1. `terraform apply`

### Problem Identified
The https://github.com/paultyng/go-newrelic/ library expects the `int` go type for the `created_at` and `updated_at` fields in the json response from the list alert policies New Relic api (see above). These properties represent the unix timestamp (epoch time) for the corresponding values. But, rather than seconds, the New Relic api returns the values as milliseconds. The current unix timestamp is currently larger than maximum value (2147483647) of a [go `int` type](https://golang.org/pkg/builtin/#int32), so the value fails to deserialize.

### Solution
I've updated the expected type to `int64` to support the larger value. A PR has been submitted to https://github.com/paultyng/go-newrelic/pull/23

Furthermore, since Terraform only supports the `int` and `float64` primitive types in their schema, https://www.terraform.io/docs/extend/schemas/schema-types.html#primitive-types, and they recommend storing date an time values as RFC 3339 formatted strings, https://www.terraform.io/docs/extend/schemas/schema-types.html#date-amp-time-data, I've updated the provider to first convert the values to a `Time` struct and then use the built in Time.Format(time.RFC3339) function to convert the values to RFC 3339 formatted strings.

### Note
I've successfully tested this update against my own New Relic account by following the directions found here: https://www.terraform.io/docs/configuration/providers.html#third-party-plugins