### PR TITLE
Use TypeSet instead of TypeList

### DIFF
--- a/newrelic/resource_newrelic_alert_condition.go
+++ b/newrelic/resource_newrelic_alert_condition.go
@@ -126,7 +126,7 @@ func resourceNewRelicAlertCondition() *schema.Resource {
 				Optional: true,
 			},
 			"term": {
-				Type: schema.TypeList,
+				Type: schema.TypeSet,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"duration": {
@@ -182,7 +182,7 @@ func buildAlertConditionStruct(d *schema.ResourceData) *newrelic.AlertCondition 
 		entities[i] = strconv.Itoa(entity.(int))
 	}
 
-	termSet := d.Get("term").([]interface{})
+	termSet := d.Get("term").(*schema.Set).List()
 	terms := make([]newrelic.AlertConditionTerm, len(termSet))
 
 	for i, termI := range termSet {


### PR DESCRIPTION
I would propose to use TypeSet instead of TypeList for the terms of the Alertconditions. https://www.terraform.io/docs/extend/schemas/schema-types.html#typeset
This should fix issue #4 

Results of the acceptance tests:
```
TF_ACC=1 go test -v github.com/terraform-providers/terraform-provider-newrelic/newrelic -run '^TestAccNewRelicInfraAlertCondition*'  -count=1 
=== RUN   TestAccNewRelicInfraAlertCondition_Basic
--- PASS: TestAccNewRelicInfraAlertCondition_Basic (11.28s)
    provider_test.go:66:
=== RUN   TestAccNewRelicInfraAlertCondition_Where
--- PASS: TestAccNewRelicInfraAlertCondition_Where (6.89s)
    provider_test.go:66:
=== RUN   TestAccNewRelicInfraAlertCondition_Thresholds
--- PASS: TestAccNewRelicInfraAlertCondition_Thresholds (11.25s)
    provider_test.go:66:
PASS
ok  	github.com/terraform-providers/terraform-provider-newrelic/newrelic	29.477s
```