### PR TITLE
Add support for AlertPolicy data source

### DIFF
--- a/newrelic/data_source_newrelic_alert_policy.go
+++ b/newrelic/data_source_newrelic_alert_policy.go
@@ -1,0 +1,69 @@
+package newrelic
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	newrelic "github.com/paultyng/go-newrelic/v4/api"
+)
+
+func dataSourceNewRelicAlertPolicy() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNewRelicAlertPolicyRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"incident_preference": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceNewRelicAlertPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ProviderConfig).Client
+
+	log.Printf("[INFO] Reading New Relic Alert Policies")
+
+	policies, err := client.ListAlertPolicies()
+	if err != nil {
+		return err
+	}
+
+	var policy *newrelic.AlertPolicy
+	name := d.Get("name").(string)
+
+	for _, c := range policies {
+		if strings.Contains(strings.ToLower(c.Name), strings.ToLower(name)) {
+			policy = &c
+			break
+		}
+	}
+
+	if policy == nil {
+		return fmt.Errorf("The name '%s' does not match any New Relic alert policy.", name)
+	}
+
+	d.SetId(strconv.Itoa(policy.ID))
+	d.Set("name", policy.Name)
+	d.Set("incident_preference", policy.IncidentPreference)
+	d.Set("created_at", policy.CreatedAt)
+	d.Set("updated_at", policy.UpdatedAt)
+
+	return nil
+}

--- a/newrelic/data_source_newrelic_alert_policy_test.go
+++ b/newrelic/data_source_newrelic_alert_policy_test.go
@@ -1,0 +1,56 @@
+package newrelic
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccNewRelicAlertPolicyDataSource_Basic(t *testing.T) {
+	rName := acctest.RandString(5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNewRelicAlertPolicyDataSourceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNewRelicAlertPolicy("data.newrelic_alert_policy.policy"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNewRelicAlertPolicy(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		if a["id"] == "" {
+			return fmt.Errorf("Expected to get an alert policy from New Relic")
+		}
+
+		if strings.Contains(strings.ToLower(testAccExpectedAlertPolicyName), strings.ToLower(a["name"])) {
+			return fmt.Errorf("Expected the alert policy name to be: %s, but got: %s", testAccExpectedAlertPolicyName, a["name"])
+		}
+
+		return nil
+	}
+}
+
+func testAccNewRelicAlertPolicyDataSourceConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "newrelic_alert_policy" "foo" {
+	name = "tf-test-%s"
+}
+
+data "newrelic_alert_policy" "policy" {
+	name = "${newrelic_alert_policy.foo.name}"
+}
+`, rName)
+}

--- a/newrelic/provider.go
+++ b/newrelic/provider.go
@@ -35,6 +35,7 @@ func Provider() terraform.ResourceProvider {
 			"newrelic_application":        dataSourceNewRelicApplication(),
 			"newrelic_key_transaction":    dataSourceNewRelicKeyTransaction(),
 			"newrelic_synthetics_monitor": dataSourceNewRelicSyntheticsMonitor(),
+			"newrelic_alert_policy":       dataSourceNewRelicAlertPolicy(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/newrelic/provider_test.go
+++ b/newrelic/provider_test.go
@@ -15,6 +15,7 @@ import (
 var (
 	testAccExpectedAlertChannelName string
 	testAccExpectedApplicationName  string
+	testAccExpectedAlertPolicyName  string
 	testAccProviders                map[string]terraform.ResourceProvider
 	testAccProvider                 *schema.Provider
 )
@@ -22,6 +23,7 @@ var (
 func init() {
 	testAccExpectedAlertChannelName = fmt.Sprintf("%s tf-test@example.com", acctest.RandString(5))
 	testAccExpectedApplicationName = fmt.Sprintf("tf_test_%s", acctest.RandString(10))
+	testAccExpectedAlertPolicyName = fmt.Sprintf("tf_test_%s", acctest.RandString(10))
 	testAccProvider = Provider().(*schema.Provider)
 	testAccProviders = map[string]terraform.ResourceProvider{
 		"newrelic": testAccProvider,

--- a/website/docs/d/alert_policy.html.markdown
+++ b/website/docs/d/alert_policy.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "newrelic"
+page_title: "New Relic: newrelic_alert_policy"
+sidebar_current: "docs-newrelic-datasource-alert-policy"
+description: |-
+  Looks up the information about an alert policy in New Relic.
+---
+
+# newrelic\_alert\_channel
+
+Use this data source to get information about an specific alert policy in New Relic which already exists.
+
+## Example Usage
+
+```hcl
+data "newrelic_alert_channel" "foo" {
+  name = "foo@example.com"
+}
+
+data "newrelic_alert_policy" "foo" {
+  name = "foo policy"
+}
+
+resource "newrelic_alert_policy_channel" "foo" {
+  policy_id  = "${data.newrelic_alert_policy.foo.id}"
+  channel_id = "${data.newrelic_alert_channel.foo.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the alert policy in New Relic.
+
+## Attributes Reference
+
+* `id` - The ID of the alert policy.
+* `incident_preference` - The rollup strategy for the policy. Options include: PER_POLICY, PER_CONDITION, or PER_CONDITION_AND_TARGET. The default is PER_POLICY.
+* `created_at` - The time the policy was created.
+* `updated_at` -  The time the policy was last updated.

--- a/website/newrelic.erb
+++ b/website/newrelic.erb
@@ -25,6 +25,9 @@
                 <li<%= sidebar_current("docs-newrelic-datasource-synthetics-monitor") %>>
                     <a href="/docs/providers/newrelic/d/synthetics_monitor.html">synthetics_monitor</a>
                 </li>
+                <li<%= sidebar_current("docs-newrelic-datasource-alert-policy") %>>
+                    <a href="/docs/providers/newrelic/d/alert_policy.html">newrelic_alert_policy</a>
+                </li>
             </ul>
         </li>
 


### PR DESCRIPTION
Hi,

This PR add the data source for searching an Alert policy by name.

Acceptance tests:

```
TF_ACC=1 go test -v github.com/terraform-providers/terraform-provider-newrelic/newrelic -run '^TestAccNewRelicAlertPolicyDataSource*'  -count=1
=== RUN   TestAccNewRelicAlertPolicyDataSource_Basic
--- PASS: TestAccNewRelicAlertPolicyDataSource_Basic (5.55s)
PASS
ok  	github.com/terraform-providers/terraform-provider-newrelic/newrelic	5.579s
```