### PR TITLE
Add newrelic_synthetics_monitor and script resources

### DIFF
--- a/newrelic/data_source_newrelic_synthetics_monitor_test.go
+++ b/newrelic/data_source_newrelic_synthetics_monitor_test.go
@@ -1,0 +1,63 @@
+package newrelic
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var (
+	expectedMonitorName string = fmt.Sprintf("tf-test-synthetic-%s", acctest.RandString(5))
+)
+
+func TestAccNewRelicSyntheticsMonitorDataSource_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckNewRelicSyntheticsDataSourceConfig(expectedMonitorName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNewRelicSyntheticsDataSource("data.newrelic_synthetics_monitor.bar"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNewRelicSyntheticsDataSource(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		if a["id"] == "" {
+			return fmt.Errorf("Expected to read synthetics monitor data from New Relic")
+		}
+
+		if a["name"] != expectedMonitorName {
+			return fmt.Errorf("Expected the synthetics monitor name to be: %s, but got: %s", expectedMonitorName, a["name"])
+		}
+		return nil
+	}
+}
+
+func testAccCheckNewRelicSyntheticsDataSourceConfig(name string) string {
+	return fmt.Sprintf(`
+
+resource "newrelic_synthetics_monitor" "foo" {
+	name = "%[1]s"
+	type = "SIMPLE"
+	frequency = 15
+	status = "DISABLED"
+	locations = ["AWS_US_EAST_1"]
+	uri = "https://google.com"
+}
+
+data "newrelic_synthetics_monitor" "bar" {
+	name = "${newrelic_synthetics_monitor.foo.name}"
+}
+`, name)
+}

--- a/newrelic/provider.go
+++ b/newrelic/provider.go
@@ -46,6 +46,7 @@ func Provider() terraform.ResourceProvider {
 			"newrelic_infra_alert_condition":      resourceNewRelicInfraAlertCondition(),
 			"newrelic_nrql_alert_condition":       resourceNewRelicNrqlAlertCondition(),
 			"newrelic_synthetics_alert_condition": resourceNewRelicSyntheticsAlertCondition(),
+			"newrelic_synthetics_monitor":         resourceNewRelicSyntheticsMonitor(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/newrelic/provider.go
+++ b/newrelic/provider.go
@@ -47,6 +47,7 @@ func Provider() terraform.ResourceProvider {
 			"newrelic_nrql_alert_condition":       resourceNewRelicNrqlAlertCondition(),
 			"newrelic_synthetics_alert_condition": resourceNewRelicSyntheticsAlertCondition(),
 			"newrelic_synthetics_monitor":         resourceNewRelicSyntheticsMonitor(),
+			"newrelic_synthetics_monitor_script":  resourceNewRelicSyntheticsMonitorScript(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/newrelic/provider.go
+++ b/newrelic/provider.go
@@ -40,12 +40,12 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"newrelic_alert_channel":              resourceNewRelicAlertChannel(),
 			"newrelic_alert_condition":            resourceNewRelicAlertCondition(),
+			"newrelic_alert_policy_channel":       resourceNewRelicAlertPolicyChannel(),
+			"newrelic_alert_policy":               resourceNewRelicAlertPolicy(),
+			"newrelic_dashboard":                  resourceNewRelicDashboard(),
+			"newrelic_infra_alert_condition":      resourceNewRelicInfraAlertCondition(),
 			"newrelic_nrql_alert_condition":       resourceNewRelicNrqlAlertCondition(),
 			"newrelic_synthetics_alert_condition": resourceNewRelicSyntheticsAlertCondition(),
-			"newrelic_infra_alert_condition":      resourceNewRelicInfraAlertCondition(),
-			"newrelic_alert_policy":               resourceNewRelicAlertPolicy(),
-			"newrelic_alert_policy_channel":       resourceNewRelicAlertPolicyChannel(),
-			"newrelic_dashboard":                  resourceNewRelicDashboard(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/newrelic/resource_newrelic_alert_channel.go
+++ b/newrelic/resource_newrelic_alert_channel.go
@@ -162,7 +162,5 @@ func resourceNewRelicAlertChannelDelete(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	d.SetId("")
-
 	return nil
 }

--- a/newrelic/resource_newrelic_alert_condition.go
+++ b/newrelic/resource_newrelic_alert_condition.go
@@ -361,7 +361,5 @@ func resourceNewRelicAlertConditionDelete(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	d.SetId("")
-
 	return nil
 }

--- a/newrelic/resource_newrelic_alert_policy.go
+++ b/newrelic/resource_newrelic_alert_policy.go
@@ -148,7 +148,5 @@ func resourceNewRelicAlertPolicyDelete(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	d.SetId("")
-
 	return nil
 }

--- a/newrelic/resource_newrelic_alert_policy_channel.go
+++ b/newrelic/resource_newrelic_alert_policy_channel.go
@@ -131,7 +131,5 @@ func resourceNewRelicAlertPolicyChannelDelete(d *schema.ResourceData, meta inter
 		}
 	}
 
-	d.SetId("")
-
 	return nil
 }

--- a/newrelic/resource_newrelic_dashboard.go
+++ b/newrelic/resource_newrelic_dashboard.go
@@ -326,13 +326,10 @@ func resourceNewRelicDashboardDelete(d *schema.ResourceData, meta interface{}) e
 
 	if err := client.DeleteDashboard(id); err != nil {
 		if err == newrelic.ErrNotFound {
-			d.SetId("")
 			return nil
 		}
 		return err
 	}
-
-	d.SetId("")
 
 	return nil
 }

--- a/newrelic/resource_newrelic_infra_alert_condition.go
+++ b/newrelic/resource_newrelic_infra_alert_condition.go
@@ -290,8 +290,6 @@ func resourceNewRelicInfraAlertConditionDelete(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	d.SetId("")
-
 	return nil
 }
 

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -265,7 +265,5 @@ func resourceNewRelicNrqlAlertConditionDelete(d *schema.ResourceData, meta inter
 		return err
 	}
 
-	d.SetId("")
-
 	return nil
 }

--- a/newrelic/resource_newrelic_synthetics_alert_condition.go
+++ b/newrelic/resource_newrelic_synthetics_alert_condition.go
@@ -162,7 +162,5 @@ func resourceNewRelicSyntheticsAlertConditionDelete(d *schema.ResourceData, meta
 		return err
 	}
 
-	d.SetId("")
-
 	return nil
 }

--- a/newrelic/resource_newrelic_synthetics_alert_condition_test.go
+++ b/newrelic/resource_newrelic_synthetics_alert_condition_test.go
@@ -23,13 +23,21 @@ func TestAccNewRelicSyntheticsAlertCondition_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"newrelic_synthetics_alert_condition.foo", "name", fmt.Sprintf("tf-test-%s", rName)),
 					resource.TestCheckResourceAttr(
-						"newrelic_synthetics_alert_condition.foo", "policy_id", "0"),
-					resource.TestCheckResourceAttr(
-						"newrelic_synthetics_alert_condition.foo", "monitor_id", "derp"),
-					resource.TestCheckResourceAttr(
 						"newrelic_synthetics_alert_condition.foo", "runbook_url", "www.example.com"),
 					resource.TestCheckResourceAttr(
 						"newrelic_synthetics_alert_condition.foo", "enabled", "true"),
+				),
+			},
+			{
+				Config: testAccCheckNewRelicSyntheticsAlertConditionUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicSyntheticsAlertConditionExists("newrelic_synthetics_alert_condition.foo"),
+					resource.TestCheckResourceAttr(
+						"newrelic_synthetics_alert_condition.foo", "name", fmt.Sprintf("tf-test-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"newrelic_synthetics_alert_condition.foo", "runbook_url", "www.example2.com"),
+					resource.TestCheckResourceAttr(
+						"newrelic_synthetics_alert_condition.foo", "enabled", "false"),
 				),
 			},
 		},
@@ -96,41 +104,51 @@ func testAccCheckNewRelicSyntheticsAlertConditionExists(n string) resource.TestC
 func testAccCheckNewRelicSyntheticsAlertConditionConfig(rName string) string {
 	return fmt.Sprintf(`
 
-data "newrelic_synthetics_monitor" "bar" {
-  name = "%[2]s"
+resource "newrelic_synthetics_monitor" "bar" {
+	name = "tf-test-synthetic-%[1]s"
+	type = "SIMPLE"
+	frequency = 15
+	status = "DISABLED"
+	locations = ["AWS_US_EAST_1"]
+	uri = "https://google.com"
 }
 
 resource "newrelic_alert_policy" "foo" {
-  name = "tf-test-%[1]s"
+	name = "tf-test-%[1]s"
 }
 
 resource "newrelic_synthetics_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
-
+	policy_id = "${newrelic_alert_policy.foo.id}"
 	name            = "tf-test-%[1]s"
-	monitor_id      = "${data.newrelic_synthetics_monitor.bar.id}"
-	runbook_url     = "https://foo.example.com"
+	monitor_id      = "${newrelic_synthetics_monitor.bar.id}"
+	runbook_url     = "www.example.com"
+	enabled			= "true"
 }
-`, rName, testAccExpectedApplicationName)
+`, rName)
 }
 
-func testAccCheckNewRelicSyntheticsAlertConditionConfigUpdated(rName string) string {
+func testAccCheckNewRelicSyntheticsAlertConditionUpdated(rName string) string {
 	return fmt.Sprintf(`
 
-data "newrelic_synthetics_monitor" "bar" {
-  name = "%[2]s"
+resource "newrelic_synthetics_monitor" "bar" {
+	name = "tf-test-synthetic-%[1]s"
+	type = "SIMPLE"
+	frequency = 15
+	status = "DISABLED"
+	locations = ["AWS_US_EAST_1"]
+	uri = "https://google.com"
 }
 
 resource "newrelic_alert_policy" "foo" {
-  name = "tf-test-%[1]s"
+	name = "tf-test-%[1]s"
 }
 
 resource "newrelic_synthetics_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
-
-	name            = "tf-test-updated-%[1]s"
-	monitor_id      = "${data.newrelic_synthetics_monitor.bar.id}"
-  runbook_url     = "https://bar.example.com"
+	policy_id = "${newrelic_alert_policy.foo.id}"
+	name            = "tf-test-%[1]s"
+	monitor_id      = "${newrelic_synthetics_monitor.bar.id}"
+	runbook_url     = "www.example2.com"
+	enabled			= "false"
 }
-`, rName, testAccExpectedApplicationName)
+`, rName)
 }

--- a/newrelic/resource_newrelic_synthetics_monitor.go
+++ b/newrelic/resource_newrelic_synthetics_monitor.go
@@ -1,0 +1,252 @@
+package newrelic
+
+import (
+	"fmt"
+	"log"
+
+	synthetics "github.com/dollarshaveclub/new-relic-synthetics-go"
+	util "github.com/dollarshaveclub/new-relic-synthetics-go/util"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceNewRelicSyntheticsMonitor() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNewRelicSyntheticsMonitorCreate,
+		Read:   resourceNewRelicSyntheticsMonitorRead,
+		Update: resourceNewRelicSyntheticsMonitorUpdate,
+		Delete: resourceNewRelicSyntheticsMonitorDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"SIMPLE",
+					"BROWSER",
+					"SCRIPT_API",
+					"SCRIPT_BROWSER",
+				}, false),
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"frequency": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: intInSlice([]int{1, 5, 10, 15, 30, 60, 360, 720, 1440}),
+			},
+			"uri": {
+				Type:     schema.TypeString,
+				Optional: true,
+				// TODO: ValidateFunc (required if SIMPLE or BROWSER)
+			},
+			"locations": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				MinItems: 1,
+				Required: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"ENABLED",
+					"MUTED",
+					"DISABLED",
+				}, false),
+			},
+			"sla_threshold": {
+				Type:     schema.TypeFloat,
+				Optional: true,
+				Default:  7,
+			},
+			// TODO: ValidationFunc (options only valid if SIMPLE or BROWSER)
+			"validation_string": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"verify_ssl": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"bypass_head_request": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"treat_redirect_as_failure": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func buildSyntheticsMonitorStruct(d *schema.ResourceData) *synthetics.CreateMonitorArgs {
+	monitor := synthetics.CreateMonitorArgs{
+		Name:         d.Get("name").(string),
+		Type:         d.Get("type").(string),
+		Frequency:    uint(d.Get("frequency").(int)),
+		Status:       d.Get("status").(string),
+		SLAThreshold: d.Get("sla_threshold").(float64),
+	}
+
+	if uri, ok := d.GetOk("uri"); ok {
+		monitor.URI = uri.(string)
+	}
+
+	locations_raw := d.Get("locations").(*schema.Set)
+	locations := make([]string, locations_raw.Len())
+	for i, v := range locations_raw.List() {
+		locations[i] = fmt.Sprint(v)
+	}
+
+	if validationString, ok := d.GetOk("validation_string"); ok {
+		monitor.ValidationString = util.StrPtr(validationString.(string))
+	}
+
+	if verifySSL, ok := d.GetOk("verify_ssl"); ok {
+		monitor.VerifySSL = util.BoolPtr(verifySSL.(bool))
+	}
+
+	if bypassHeadRequest, ok := d.GetOk("bypass_head_request"); ok {
+		monitor.BypassHEADRequest = util.BoolPtr(bypassHeadRequest.(bool))
+	}
+
+	if treatRedirectAsFailure, ok := d.GetOk("treat_redirect_as_failure"); ok {
+		monitor.TreatRedirectAsFailure = util.BoolPtr(treatRedirectAsFailure.(bool))
+	}
+
+	monitor.Locations = locations
+	return &monitor
+}
+
+func buildSyntheticsUpdateMonitorArgs(d *schema.ResourceData) *synthetics.UpdateMonitorArgs {
+	monitor := synthetics.UpdateMonitorArgs{
+		Name:         d.Get("name").(string),
+		Frequency:    uint(d.Get("frequency").(int)),
+		Status:       d.Get("status").(string),
+		SLAThreshold: d.Get("sla_threshold").(float64),
+	}
+
+	if uri, ok := d.GetOk("uri"); ok {
+		monitor.URI = uri.(string)
+	}
+
+	locations_raw := d.Get("locations").(*schema.Set)
+	locations := make([]string, locations_raw.Len())
+	for i, v := range locations_raw.List() {
+		locations[i] = fmt.Sprint(v)
+	}
+
+	if validationString, ok := d.GetOk("validation_string"); ok {
+		monitor.ValidationString = util.StrPtr(validationString.(string))
+	}
+
+	if verifySSL, ok := d.GetOk("verify_ssl"); ok {
+		monitor.VerifySSL = util.BoolPtr(verifySSL.(bool))
+	}
+
+	if bypassHeadRequest, ok := d.GetOk("bypass_head_request"); ok {
+		monitor.BypassHEADRequest = util.BoolPtr(bypassHeadRequest.(bool))
+	}
+
+	if treatRedirectAsFailure, ok := d.GetOk("treat_redirect_as_failure"); ok {
+		monitor.TreatRedirectAsFailure = util.BoolPtr(treatRedirectAsFailure.(bool))
+	}
+
+	monitor.Locations = locations
+	return &monitor
+}
+
+func readSyntheticsMonitorStruct(monitor *synthetics.Monitor, d *schema.ResourceData) error {
+	d.Set("name", monitor.Name)
+	d.Set("type", monitor.Type)
+	d.Set("frequency", monitor.Frequency)
+	d.Set("uri", monitor.URI)
+	d.Set("locations", monitor.Locations)
+	d.Set("status", monitor.Status)
+	d.Set("sla_threshold", monitor.SLAThreshold)
+
+	if monitor.VerifySSL != nil {
+		d.Set("verify_ssl", *monitor.VerifySSL)
+	}
+
+	if monitor.ValidationString != nil {
+		d.Set("validation_string", *monitor.ValidationString)
+	}
+
+	if monitor.BypassHEADRequest != nil {
+		d.Set("bypass_head_request", monitor.BypassHEADRequest)
+	}
+
+	if monitor.TreatRedirectAsFailure != nil {
+		d.Set("treat_redirect_as_failure", monitor.TreatRedirectAsFailure)
+	}
+
+	return nil
+}
+
+func resourceNewRelicSyntheticsMonitorCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ProviderConfig).Synthetics
+	monitor := buildSyntheticsMonitorStruct(d)
+
+	log.Printf("[INFO] Creating New Relic Synthetics monitor %s", monitor.Name)
+
+	condition, err := client.CreateMonitor(monitor)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(condition.ID)
+	return resourceNewRelicSyntheticsMonitorRead(d, meta)
+}
+
+func resourceNewRelicSyntheticsMonitorRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ProviderConfig).Synthetics
+
+	log.Printf("[INFO] Reading New Relic Synthetics monitor %s", d.Id())
+
+	monitor, err := client.GetMonitor(d.Id())
+	if err != nil {
+		if err == synthetics.ErrMonitorNotFound {
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	return readSyntheticsMonitorStruct(monitor, d)
+}
+
+func resourceNewRelicSyntheticsMonitorUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ProviderConfig).Synthetics
+	monitor := buildSyntheticsUpdateMonitorArgs(d)
+
+	log.Printf("[INFO] Updating New Relic Synthetics monitor %s", d.Id())
+
+	_, err := client.UpdateMonitor(d.Id(), monitor)
+	if err != nil {
+		return err
+	}
+
+	return resourceNewRelicSyntheticsMonitorRead(d, meta)
+}
+
+func resourceNewRelicSyntheticsMonitorDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ProviderConfig).Synthetics
+
+	log.Printf("[INFO] Deleting New Relic Synthetics monitor %s", d.Id())
+
+	if err := client.DeleteMonitor(d.Id()); err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/newrelic/resource_newrelic_synthetics_monitor.go
+++ b/newrelic/resource_newrelic_synthetics_monitor.go
@@ -247,6 +247,5 @@ func resourceNewRelicSyntheticsMonitorDelete(d *schema.ResourceData, meta interf
 		return err
 	}
 
-	d.SetId("")
 	return nil
 }

--- a/newrelic/resource_newrelic_synthetics_monitor_script.go
+++ b/newrelic/resource_newrelic_synthetics_monitor_script.go
@@ -1,0 +1,111 @@
+package newrelic
+
+import (
+	"log"
+
+	synthetics "github.com/dollarshaveclub/new-relic-synthetics-go"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceNewRelicSyntheticsMonitorScript() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNewRelicSyntheticsMonitorScriptCreate,
+		Read:   resourceNewRelicSyntheticsMonitorScriptRead,
+		Update: resourceNewRelicSyntheticsMonitorScriptUpdate,
+		Delete: resourceNewRelicSyntheticsMonitorScriptDelete,
+		Importer: &schema.ResourceImporter{
+			State: importSyntheticsMonitorScript,
+		},
+		Schema: map[string]*schema.Schema{
+			"monitor_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"text": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func importSyntheticsMonitorScript(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	d.Set("monitor_id", d.Id())
+	return []*schema.ResourceData{d}, nil
+}
+
+func buildSyntheticsMonitorScriptStruct(d *schema.ResourceData) *synthetics.UpdateMonitorScriptArgs {
+	script := synthetics.UpdateMonitorScriptArgs{
+		ScriptText: d.Get("text").(string),
+	}
+
+	return &script
+}
+
+func resourceNewRelicSyntheticsMonitorScriptCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ProviderConfig).Synthetics
+	script := buildSyntheticsMonitorScriptStruct(d)
+
+	id := d.Get("monitor_id").(string)
+	log.Printf("[INFO] Creating New Relic Synthetics monitor script %s", id)
+
+	err := client.UpdateMonitorScript(id, script)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(id)
+	return resourceNewRelicSyntheticsMonitorScriptRead(d, meta)
+}
+
+func resourceNewRelicSyntheticsMonitorScriptRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ProviderConfig).Synthetics
+
+	log.Printf("[INFO] Reading New Relic Synthetics script %s", d.Id())
+
+	scriptText, err := client.GetMonitorScript(d.Id())
+	if err != nil {
+		if err == synthetics.ErrMonitorScriptNotFound {
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	d.Set("text", scriptText)
+	return nil
+}
+
+func resourceNewRelicSyntheticsMonitorScriptUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ProviderConfig).Synthetics
+	script := buildSyntheticsMonitorScriptStruct(d)
+
+	log.Printf("[INFO] Creating New Relic Synthetics monitor script %s", d.Id())
+
+	err := client.UpdateMonitorScript(d.Id(), script)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(d.Id())
+	return resourceNewRelicSyntheticsMonitorScriptRead(d, meta)
+}
+
+func resourceNewRelicSyntheticsMonitorScriptDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ProviderConfig).Synthetics
+
+	log.Printf("[INFO] Deleting New Relic Synthetics monitor script %s", d.Id())
+
+	script := synthetics.UpdateMonitorScriptArgs{
+		ScriptText: " ",
+	}
+
+	if err := client.UpdateMonitorScript(d.Id(), &script); err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/newrelic/resource_newrelic_synthetics_monitor_script.go
+++ b/newrelic/resource_newrelic_synthetics_monitor_script.go
@@ -106,6 +106,5 @@ func resourceNewRelicSyntheticsMonitorScriptDelete(d *schema.ResourceData, meta 
 		return err
 	}
 
-	d.SetId("")
 	return nil
 }

--- a/newrelic/resource_newrelic_synthetics_monitor_script_test.go
+++ b/newrelic/resource_newrelic_synthetics_monitor_script_test.go
@@ -1,0 +1,100 @@
+package newrelic
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccNewRelicSyntheticsMonitorScript_Basic(t *testing.T) {
+	rname := acctest.RandString(5)
+	scriptText := acctest.RandString(5)
+	scriptTextUpdated := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicSyntheticsMonitorScriptDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckNewRelicSyntheticsMonitorScriptConfig(rname, scriptText),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicSyntheticsMonitorScriptExists("newrelic_synthetics_monitor_script.foo_script"),
+					resource.TestCheckResourceAttr(
+						"newrelic_synthetics_monitor_script.foo_script", "text", scriptText),
+				),
+			},
+			{
+				Config: testAccCheckNewRelicSyntheticsMonitorScriptConfig(rname, scriptTextUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicSyntheticsMonitorScriptExists("newrelic_synthetics_monitor_script.foo_script"),
+					resource.TestCheckResourceAttr(
+						"newrelic_synthetics_monitor_script.foo_script", "text", scriptTextUpdated),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckNewRelicSyntheticsMonitorScriptExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No synthetics monitor script ID is set")
+		}
+
+		client := testAccProvider.Meta().(*ProviderConfig).Synthetics
+
+		foundText, err := client.GetMonitorScript(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if foundText != rs.Primary.Attributes["text"] {
+			return fmt.Errorf("Synthetics monitor script text does not match: %v \n\n %v", foundText, rs.Primary.Attributes["text"])
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckNewRelicSyntheticsMonitorScriptDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*ProviderConfig).Synthetics
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "newrelic_synthetics_monitor_script" {
+			continue
+		}
+
+		foundText, err := client.GetMonitorScript(r.Primary.ID)
+		if err == nil || strings.TrimSpace(foundText) != "" {
+			return fmt.Errorf("Synthetics monitor script text still exists")
+		}
+	}
+	return nil
+}
+
+func testAccCheckNewRelicSyntheticsMonitorScriptConfig(rName string, scriptText string) string {
+	return fmt.Sprintf(`
+
+resource "newrelic_synthetics_monitor" "foo" {
+  name = "%[1]s"
+  type = "SCRIPT_BROWSER"
+  frequency = 1
+  status = "DISABLED"
+  locations = ["AWS_US_EAST_1"]
+  uri = "https://google.com"
+}
+
+resource "newrelic_synthetics_monitor_script" "foo_script" {
+  monitor_id = "${newrelic_synthetics_monitor.foo.id}"
+  text = "%[2]s"
+}
+`, rName, scriptText)
+}

--- a/newrelic/resource_newrelic_synthetics_monitor_test.go
+++ b/newrelic/resource_newrelic_synthetics_monitor_test.go
@@ -1,0 +1,126 @@
+package newrelic
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccNewRelicSyntheticsMonitor_Basic(t *testing.T) {
+	rName := acctest.RandString(5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicSyntheticsMonitorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckNewRelicSyntheticsMonitorConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicSyntheticsMonitorExists("newrelic_synthetics_monitor.foo"),
+					resource.TestCheckResourceAttr(
+						"newrelic_synthetics_monitor.foo", "name", rName),
+					resource.TestCheckResourceAttr(
+						"newrelic_synthetics_monitor.foo", "type", "SIMPLE"),
+					resource.TestCheckResourceAttr(
+						"newrelic_synthetics_monitor.foo", "frequency", "1"),
+					resource.TestCheckResourceAttr(
+						"newrelic_synthetics_monitor.foo", "status", "DISABLED"),
+					resource.TestCheckResourceAttr(
+						"newrelic_synthetics_monitor.foo", "uri", "https://google.com"),
+					resource.TestCheckResourceAttr(
+						"newrelic_synthetics_monitor.foo", "locations.#", "1"),
+				),
+			},
+			{
+				Config: testAccCheckNewRelicSyntheticsMonitorConfigUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicSyntheticsMonitorExists("newrelic_synthetics_monitor.foo"),
+					resource.TestCheckResourceAttr(
+						"newrelic_synthetics_monitor.foo", "name", fmt.Sprintf("%s-updated", rName)),
+					resource.TestCheckResourceAttr(
+						"newrelic_synthetics_monitor.foo", "type", "SIMPLE"),
+					resource.TestCheckResourceAttr(
+						"newrelic_synthetics_monitor.foo", "frequency", "5"),
+					resource.TestCheckResourceAttr(
+						"newrelic_synthetics_monitor.foo", "status", "ENABLED"),
+					resource.TestCheckResourceAttr(
+						"newrelic_synthetics_monitor.foo", "uri", "https://github.com"),
+					resource.TestCheckResourceAttr(
+						"newrelic_synthetics_monitor.foo", "locations.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckNewRelicSyntheticsMonitorExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No synthetics monitor ID is set")
+		}
+
+		client := testAccProvider.Meta().(*ProviderConfig).Synthetics
+
+		found, err := client.GetMonitor(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("Synthetics monitor not found: %v - %v", rs.Primary.ID, found)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckNewRelicSyntheticsMonitorDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*ProviderConfig).Synthetics
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "newrelic_synthetics_monitor" {
+			continue
+		}
+
+		_, err := client.GetMonitor(r.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("Synthetics monitor still exists")
+		}
+
+	}
+	return nil
+}
+
+func testAccCheckNewRelicSyntheticsMonitorConfig(rName string) string {
+	return fmt.Sprintf(`
+
+resource "newrelic_synthetics_monitor" "foo" {
+  name = "%[1]s"
+  type = "SIMPLE"
+  frequency = 1
+  status = "DISABLED"
+  locations = ["AWS_US_EAST_1"]
+  uri = "https://google.com"
+}
+`, rName)
+}
+
+func testAccCheckNewRelicSyntheticsMonitorConfigUpdated(rName string) string {
+	return fmt.Sprintf(`
+
+resource "newrelic_synthetics_monitor" "foo" {
+  name = "%[1]s-updated"
+  type = "SIMPLE"
+  frequency = 5
+  status = "ENABLED"
+  locations = ["AWS_US_EAST_1", "AWS_US_WEST_1"]
+  uri = "https://github.com"
+}
+`, rName)
+}

--- a/website/docs/r/synthetics_monitor.html.markdown
+++ b/website/docs/r/synthetics_monitor.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "newrelic"
+page_title: "New Relic: newrelic_synthetics_monitor"
+sidebar_current: "docs-newrelic-resource-synthetics-monitor"
+description: |-
+  Create and manage a Synthetics monitor in New Relic.
+---
+
+# newrelic\_synthetics\_monitor
+
+Use this resource to create, update, and delete a synthetics monitor in New Relic.
+
+## Example Usage
+
+```hcl
+resource "newrelic_synthetics_monitor" "foo" {
+  name = "foo"
+  type = "SIMPLE"
+  frequency = 5
+  status = "ENABLED"
+  locations = ["AWS_US_EAST_1"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+  * `name` - (Required) The title of this monitor.
+  * `type` - (Required) The monitor type.
+  * `frequency` - (Required) The interval (in minutes) at which this monitor should run.
+  * `status` - (Required) The monitor status (i.e. ENABLED, MUTED, DISABLED)
+  * `locations` - (Required) The locations in which this monitor should be run.
+  * `sla_threshold` - (Optional) The base threshold for the SLA report.
+  
+For SIMPLE and BROWSER monitor types, the following arguments are also supported:
+
+  * `uri` - (Required) The URI for the monitor to hit.
+  * `validation_string` - (Optional) The string to validate against in the response.
+  * `verify_ssl` - (Optional) Verify SSL.
+  * `bypass_head_request` - (Optional) Bypass HEAD request.
+  * `treat_redirect_as_faiure` - (Optional) Fail the monitor check if redirected.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+  * `id` - The ID of the Synthetics monitor.

--- a/website/docs/r/synthetics_monitor_script.html.markdown
+++ b/website/docs/r/synthetics_monitor_script.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "newrelic"
+page_title: "New Relic: newrelic_synthetics_monitor_script"
+sidebar_current: "docs-newrelic-resource-synthetics-monitor-script"
+description: |-
+  Update and manage a Synthetics monitor script in New Relic.
+---
+
+# newrelic\_synthetics\_monitor\_script
+
+Use this resource to update a synthetics monitor script in New Relic.
+
+## Example Usage
+
+```hcl
+data "template_file" "foo_script" {
+  template = "${file("${path.module}/foo_script.tpl")}"
+}
+
+resource "newrelic_synthetics_monitor_script" "foo_script" {
+  monitor_id = "${newrelic_synthetics_monitor.foo.id}"
+  text = "${data.template_file.foo_script.rendered}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+  * `monitor_id` - (Required) The ID of the monitor to attach the script to.
+  * `text` - (Required) plaintext of the monitor script.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+  * `id` - The ID of the Synthetics monitor that the script is attached to.

--- a/website/newrelic.erb
+++ b/website/newrelic.erb
@@ -55,6 +55,9 @@
                 <li<%= sidebar_current("docs-newrelic-synthetics-monitor") %>>
                     <a href="/docs/providers/newrelic/r/synthetics_monitor.html">newrelic_synthetics_monitor</a>
                 </li>
+                <li<%= sidebar_current("docs-newrelic-synthetics-monitor_script") %>>
+                    <a href="/docs/providers/newrelic/r/synthetics_monitor_script.html">newrelic_synthetics_monitor_script</a>
+                </li>
                 <li<%= sidebar_current("docs-newrelic-resource-dashboard") %>>
                     <a href="/docs/providers/newrelic/r/dashboard.html">newrelic_dashboard</a>
                 </li>

--- a/website/newrelic.erb
+++ b/website/newrelic.erb
@@ -52,6 +52,9 @@
                 <li<%= sidebar_current("docs-newrelic-synthetics-alert-condition") %>>
                     <a href="/docs/providers/newrelic/r/synthetics_alert_condition.html">newrelic_synthetics_alert_condition</a>
                 </li>
+                <li<%= sidebar_current("docs-newrelic-synthetics-monitor") %>>
+                    <a href="/docs/providers/newrelic/r/synthetics_monitor.html">newrelic_synthetics_monitor</a>
+                </li>
                 <li<%= sidebar_current("docs-newrelic-resource-dashboard") %>>
                     <a href="/docs/providers/newrelic/r/dashboard.html">newrelic_dashboard</a>
                 </li>


### PR DESCRIPTION
## What

This adds two new resources for maintaining synthetics monitor scripts:

```
newrelic_synthetics_monitor
newrelic_synthetics_monitor_script
```

Closes #65.

## Notes

Things I left out of this PR:
- Some validation around required/unsupported options based on the monitor type
- Monitor script locations (describing HMACs for secure locations)

And some quirks:
- I defined the script separately from the monitor since it uses a different endpoint, but New Relic doesn't support deleting a script from a monitor, so instead I just set it to `" "`. The script also doesn't have a real ID, so I'm relying on the monitor ID.

Happy to hear of better ways to do ^ or to improve the proposed API in general.

## Testing

I was able to:
- import existing SCRIPT_API monitors into the state without tfstate discrepancies
- create/modify/delete valid monitors and scripts from scratch without tfstate discrepancies