### PR TITLE
#3 Make resource_newrelic_alert_condition enabled status configurable

### DIFF
--- a/newrelic/resource_newrelic_alert_condition.go
+++ b/newrelic/resource_newrelic_alert_condition.go
@@ -92,6 +92,11 @@ func resourceNewRelicAlertCondition() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 			"type": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -200,7 +205,7 @@ func buildAlertConditionStruct(d *schema.ResourceData) *newrelic.AlertCondition 
 	condition := newrelic.AlertCondition{
 		Type:                d.Get("type").(string),
 		Name:                d.Get("name").(string),
-		Enabled:             true,
+		Enabled:             d.Get("enabled").(bool),
 		Entities:            entities,
 		Metric:              d.Get("metric").(string),
 		Terms:               terms,
@@ -245,6 +250,7 @@ func readAlertConditionStruct(condition *newrelic.AlertCondition, d *schema.Reso
 
 	d.Set("policy_id", policyID)
 	d.Set("name", condition.Name)
+	d.Set("enabled", condition.Enabled)
 	d.Set("type", condition.Type)
 	d.Set("metric", condition.Metric)
 	d.Set("runbook_url", condition.RunbookURL)

--- a/newrelic/resource_newrelic_alert_condition_test.go
+++ b/newrelic/resource_newrelic_alert_condition_test.go
@@ -25,6 +25,8 @@ func TestAccNewRelicAlertCondition_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"newrelic_alert_condition.foo", "type", "apm_app_metric"),
 					resource.TestCheckResourceAttr(
+						"newrelic_alert_condition.foo", "enabled", "false"),
+					resource.TestCheckResourceAttr(
 						"newrelic_alert_condition.foo", "runbook_url", "https://foo.example.com"),
 					resource.TestCheckResourceAttr(
 						"newrelic_alert_condition.foo", "entities.#", "1"),
@@ -48,6 +50,8 @@ func TestAccNewRelicAlertCondition_Basic(t *testing.T) {
 					testAccCheckNewRelicAlertConditionExists("newrelic_alert_condition.foo"),
 					resource.TestCheckResourceAttr(
 						"newrelic_alert_condition.foo", "name", fmt.Sprintf("tf-test-updated-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"newrelic_alert_condition.foo", "enabled", "true"),
 					resource.TestCheckResourceAttr(
 						"newrelic_alert_condition.foo", "runbook_url", "https://bar.example.com"),
 					resource.TestCheckResourceAttr(
@@ -83,6 +87,8 @@ func TestAccNewRelicAlertCondition_ZeroThreshold(t *testing.T) {
 					testAccCheckNewRelicAlertConditionExists("newrelic_alert_condition.foo"),
 					resource.TestCheckResourceAttr(
 						"newrelic_alert_condition.foo", "name", fmt.Sprintf("tf-test-%s", rName)),
+					resource.TestCheckResourceAttr(
+						"newrelic_alert_condition.foo", "enabled", "false"),
 					resource.TestCheckResourceAttr(
 						"newrelic_alert_condition.foo", "type", "apm_app_metric"),
 					resource.TestCheckResourceAttr(
@@ -202,6 +208,7 @@ resource "newrelic_alert_condition" "foo" {
   policy_id = "${newrelic_alert_policy.foo.id}"
 
   name            = "tf-test-%[1]s"
+  enabled         = false
   type            = "apm_app_metric"
   entities        = ["${data.newrelic_application.app.id}"]
   metric          = "apdex"
@@ -233,6 +240,7 @@ resource "newrelic_alert_condition" "foo" {
   policy_id = "${newrelic_alert_policy.foo.id}"
 
   name            = "tf-test-updated-%[1]s"
+  enabled         = true  
   type            = "apm_app_metric"
   entities        = ["${data.newrelic_application.app.id}"]
   metric          = "apdex"
@@ -264,6 +272,7 @@ resource "newrelic_alert_condition" "foo" {
   policy_id = "${newrelic_alert_policy.foo.id}"
 
   name            = "tf-test-%[1]s"
+  enabled         = false  
   type            = "apm_app_metric"
   entities        = ["${data.newrelic_application.app.id}"]
   metric          = "apdex"


### PR DESCRIPTION
This PR is depends on changes from https://github.com/paultyng/go-newrelic/pull/27 which has been merged, but not released and pulled into this project.  I've tested by manually pulling in the change and it works as expected.  Without the dependent change, you can't update a condition to switch from enabled to disabled.

@bridgetlane, I may need help from you and/or @paultyng to release and pull in the dependent change in the go-newrelic module. 

As a side note, your README is out of date and still references the use of govendor, but it seems you've switched over to go modules, so that might need an update.