### PR TITLE
include space to `format nrql_alert_condition.html.markdown` properly

### DIFF
--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -65,7 +65,7 @@ The `term` mapping supports the following arguments:
 
 The `nrql` attribute supports the following arguments:
 
-  * `query` - (Required) The NRQL query to execute for the condition
+  * `query` - (Required) The NRQL query to execute for the condition.
   * `since_value` - (Required) The value to be used in the `SINCE <X> MINUTES AGO` clause for the NRQL query. Must be: `1`, `2`, `3`, `4`, or `5`.
 
 ## Attributes Reference

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -64,6 +64,7 @@ The `term` mapping supports the following arguments:
 ## NRQL
 
 The `nrql` attribute supports the following arguments:
+
   * `query` - (Required) The NRQL query to execute for the condition
   * `since_value` - (Required) The value to be used in the `SINCE <X> MINUTES AGO` clause for the NRQL query. Must be: `1`, `2`, `3`, `4`, or `5`.
 


### PR DESCRIPTION
this fixes the `nrql_alert_condition.html` page that does not display the `NRQL` section properly. 

![image](https://user-images.githubusercontent.com/13855668/51948548-c3b9f780-23dd-11e9-8c60-b8e351f0c18d.png)
