### PR TITLE
add alert condition name validation

### DIFF
--- a/newrelic/resource_newrelic_alert_condition.go
+++ b/newrelic/resource_newrelic_alert_condition.go
@@ -89,8 +89,9 @@ func resourceNewRelicAlertCondition() *schema.Resource {
 				ForceNew: true,
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 64),
 			},
 			"type": {
 				Type:         schema.TypeString,

--- a/newrelic/resource_newrelic_alert_condition_test.go
+++ b/newrelic/resource_newrelic_alert_condition_test.go
@@ -2,6 +2,7 @@ package newrelic
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -188,6 +189,21 @@ func testAccCheckNewRelicAlertConditionExists(n string) resource.TestCheckFunc {
 	}
 }
 
+func TestErrorThrownUponConditionNameGreaterThan64Char(t *testing.T) {
+	expectedErrorMsg, _ := regexp.Compile("expected length of name to be in the range \\(1 \\- 64\\)")
+	rName := acctest.RandString(5)
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config:      testErrorThrownUponConditionNameGreaterThan64Char(rName),
+				ExpectError: expectedErrorMsg,
+			},
+		},
+	})
+}
+
 func testAccCheckNewRelicAlertConditionConfig(rName string) string {
 	return fmt.Sprintf(`
 data "newrelic_application" "app" {
@@ -279,6 +295,30 @@ resource "newrelic_alert_condition" "foo" {
   }
 }
 `, rName, testAccExpectedApplicationName)
+}
+
+func testErrorThrownUponConditionNameGreaterThan64Char(resourceName string) string {
+	return fmt.Sprintf(`
+resource "newrelic_alert_policy" "foo" {
+  name = "tf-test-%[1]s"
+}
+resource "newrelic_alert_condition" "foo" {
+  policy_id = "${newrelic_alert_policy.foo.id}"
+  name            = "really-long-name-that-is-more-than-sixtyfour-characters-long-tf-test-%[1]s"
+  type            = "apm_app_metric"
+  entities        = ["12345"]
+  metric          = "apdex"
+  runbook_url     = "https://foo.example.com"
+  condition_scope = "application"
+  term {
+    duration      = 5
+    operator      = "below"
+    priority      = "critical"
+    threshold     = "0.75"
+    time_function = "all"
+  }
+}
+`, resourceName, testAccExpectedApplicationName)
 }
 
 // TODO: const testAccCheckNewRelicAlertConditionConfigMulti = `

--- a/website/docs/r/alert_condition.html.markdown
+++ b/website/docs/r/alert_condition.html.markdown
@@ -43,7 +43,7 @@ resource "newrelic_alert_condition" "foo" {
 The following arguments are supported:
 
   * `policy_id` - (Required) The ID of the policy where this condition should be used.
-  * `name` - (Required) The title of the condition
+  * `name` - (Required) The title of the condition. Must be between 1 and 64 characters, inclusive.
   * `type` - (Required) The type of condition. One of: `apm_app_metric`, `apm_jvm_metric`, `apm_kt_metric`, `servers_metric`, `browser_metric`, `mobile_metric`
   * `entities` - (Required) The instance IDS associated with this condition.
   * `metric` - (Required) The metric field accepts parameters based on the `type` set.


### PR DESCRIPTION
The New Relic API enforces a 64 character limit on alert condition
names as described in [the documentation](https://docs.newrelic.com/docs/alerts/new-relic-alerts/defining-conditions/define-alert-conditions#rename-condition). This pull request validates the alert condition name before making a request to the API.