### PR TITLE
Modify alert_channel to use maps for headers, payload

### DIFF
--- a/newrelic/resource_newrelic_alert_channel.go
+++ b/newrelic/resource_newrelic_alert_channel.go
@@ -50,9 +50,7 @@ var alertChannelTypes = map[string][]string{
 		"auth_type",
 		"auth_username",
 		"base_url",
-		"headers",
 		"payload_type",
-		"payload",
 	},
 }
 
@@ -89,7 +87,33 @@ func resourceNewRelicAlertChannel() *schema.Resource {
 				//TODO: ValidateFunc: (use list of keys from map above)
 				Sensitive: true,
 			},
+			"headers": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+				Sensitive: true,
+			},
+			"payload": {
+				Type:         schema.TypeMap,
+				Optional:     true,
+				ForceNew:     true,
+				Sensitive:    true,
+				ValidateFunc: configBlockLengthGreaterThan(0),
+			},
 		},
+	}
+}
+
+// This function verifies that the number of keys within a configuration
+// map is greater than the provided parameter.
+func configBlockLengthGreaterThan(minLength int) schema.SchemaValidateFunc {
+	return func(i interface{}, st string) (s []string, errorSlice []error) {
+		length := len(i.(map[string]interface{}))
+		if length > minLength {
+			return
+		}
+		errorSlice = append(errorSlice, fmt.Errorf("expected %s not to be empty", st))
+		return
 	}
 }
 
@@ -98,6 +122,14 @@ func buildAlertChannelStruct(d *schema.ResourceData) *newrelic.AlertChannel {
 		Name:          d.Get("name").(string),
 		Type:          d.Get("type").(string),
 		Configuration: d.Get("configuration").(map[string]interface{}),
+	}
+
+	if headerMap, ok := d.GetOk("headers"); ok {
+		channel.Configuration["headers"] = headerMap.(map[string]interface{})
+	}
+
+	if payload, ok := d.GetOk("payload"); ok {
+		channel.Configuration["payload"] = payload.(map[string]interface{})
 	}
 
 	return &channel
@@ -141,6 +173,19 @@ func resourceNewRelicAlertChannelRead(d *schema.ResourceData, meta interface{}) 
 
 	d.Set("name", channel.Name)
 	d.Set("type", channel.Type)
+
+	// extract headers from Configuration before we try and set it in the resource
+	if headers, ok := channel.Configuration["headers"]; ok {
+		d.Set("headers", headers)
+		delete(channel.Configuration, "headers")
+	}
+
+	// extract payload from Configuration before we try and set it in the resource
+	if payload, ok := channel.Configuration["payload"]; ok {
+		d.Set("payload", payload)
+		delete(channel.Configuration, "payload")
+	}
+
 	if err := d.Set("configuration", channel.Configuration); err != nil {
 		return fmt.Errorf("[DEBUG] Error setting Alert Channel Configuration: %#v", err)
 	}

--- a/website/docs/r/alert_channel.html.markdown
+++ b/website/docs/r/alert_channel.html.markdown
@@ -10,6 +10,7 @@ description: |-
 
 ## Example Usage
 
+Example email channel:
 ```hcl
 resource "newrelic_alert_channel" "foo" {
   name = "foo"
@@ -22,6 +23,42 @@ resource "newrelic_alert_channel" "foo" {
 }
 ```
 
+Example webhook channel:
+
+```hcl
+resource "newrelic_alert_channel" "bar" {
+  name = "bar"
+  type = "webhook"
+
+  configuration = {
+    base_url = "http://test.com",
+    auth_username = "username",
+    auth_password = "password",
+    payload_type  = "application/json",
+  }
+
+  headers {
+    api-key = "my-internal-api-key"
+  }
+
+  payload {
+    # using all the default fields
+    account_id                       = "$ACCOUNT_ID"
+    account_name                     = "$ACCOUNT_NAME"
+    closed_violations_count_critical = "$CLOSED_VIOLATIONS_COUNT_CRITICAL"
+    closed_violations_count_warning  = "$CLOSED_VIOLATIONS_COUNT_WARNING"
+    condition_family_id              = "$CONDITION_FAMILY_ID"
+    #... some defaults not shown ...
+    timestamp = "$TIMESTAMP"
+    violation_callback_url           = "$VIOLATION_CALLBACK_URL"
+    violation_chart_url              = "$VIOLATION_CHART_URL"
+
+    # add our own custom field
+    my_custom_field                  = "my custom value"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -29,6 +66,11 @@ The following arguments are supported:
   * `name` - (Required) The name of the channel.
   * `type` - (Required) The type of channel.  One of: `campfire`, `email`, `hipchat`, `opsgenie`, `pagerduty`, `slack`, `victorops`, or `webhook`.
   * `configuration` - (Required) A map of key / value pairs with channel type specific values.
+
+Additionally, Webhook channels can have the following optional fields:
+
+  * `headers` - (Optional) A map of key / value pairs of HTTP headers to add to the webhook request.
+  * `payload` - (Optional) A map of key / value pairs to be sent as the webhook's payload. Fully replaces the [default payload](https://docs.newrelic.com/docs/alerts/rest-api-alerts/new-relic-alerts-rest-api/rest-api-calls-new-relic-alerts#webhook_json_channel). See [Webhook Documentation](https://docs.newrelic.com/docs/alerts/new-relic-alerts/managing-notification-channels/customize-your-webhook-payload#variables) for fields and values that New Relic provides.
 
 ## Attributes Reference
 


### PR DESCRIPTION
A possible solution for #66 - this change:
- un/marshalls headers and payload into separate maps
- tests various configurations of these optional fields
- documents these fields with examples