### PR TITLE
Relax NRQL condition limitations

### DIFF
--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -52,7 +52,7 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 						"since_value": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: StringIntBetween(1, 20),
+							ValidateFunc: stringIntBetween(1, 20),
 						},
 					},
 				},

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -52,7 +52,7 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 						"since_value": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"1", "2", "3", "4", "5"}, false),
+							ValidateFunc: StringIntBetween(1, 20),
 						},
 					},
 				},

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -64,7 +64,7 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 						"duration": {
 							Type:         schema.TypeInt,
 							Required:     true,
-							ValidateFunc: intInSlice([]int{1, 2, 3, 4, 5, 10, 15, 30, 60, 120}),
+							ValidateFunc: validation.IntAtLeast(1),
 						},
 						"operator": {
 							Type:         schema.TypeString,

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -29,7 +29,7 @@ func TestAccNewRelicNrqlAlertCondition_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"newrelic_nrql_alert_condition.foo", "term.#", "1"),
 					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.0.duration", "5"),
+						"newrelic_nrql_alert_condition.foo", "term.0.duration", "55"),
 					resource.TestCheckResourceAttr(
 						"newrelic_nrql_alert_condition.foo", "term.0.operator", "below"),
 					resource.TestCheckResourceAttr(
@@ -59,7 +59,7 @@ func TestAccNewRelicNrqlAlertCondition_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"newrelic_nrql_alert_condition.foo", "term.#", "1"),
 					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.0.duration", "10"),
+						"newrelic_nrql_alert_condition.foo", "term.0.duration", "100"),
 					resource.TestCheckResourceAttr(
 						"newrelic_nrql_alert_condition.foo", "term.0.operator", "below"),
 					resource.TestCheckResourceAttr(
@@ -154,7 +154,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
   enabled         = false
 
   term {
-    duration      = 5
+    duration      = 55
     operator      = "below"
     priority      = "critical"
     threshold     = "0.75"
@@ -184,7 +184,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
   enabled         = false
 
   term {
-    duration      = 10
+    duration      = 100
     operator      = "below"
     priority      = "critical"
     threshold     = "0.65"

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -43,7 +43,7 @@ func TestAccNewRelicNrqlAlertCondition_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"newrelic_nrql_alert_condition.foo", "nrql.0.query", "SELECT uniqueCount(hostname) FROM ComputeSample"),
 					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "nrql.0.since_value", "5"),
+						"newrelic_nrql_alert_condition.foo", "nrql.0.since_value", "20"),
 				),
 			},
 			{
@@ -73,7 +73,7 @@ func TestAccNewRelicNrqlAlertCondition_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"newrelic_nrql_alert_condition.foo", "nrql.0.query", "SELECT uniqueCount(hostname) as Hosts FROM ComputeSample"),
 					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "nrql.0.since_value", "3"),
+						"newrelic_nrql_alert_condition.foo", "nrql.0.since_value", "1"),
 				),
 			},
 		},
@@ -162,7 +162,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
   }
   nrql {
     query         = "SELECT uniqueCount(hostname) FROM ComputeSample"
-    since_value   = "5"
+    since_value   = "20"
   }
   value_function  = "single_value"
 }
@@ -192,7 +192,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
   }
   nrql {
     query         = "SELECT uniqueCount(hostname) as Hosts FROM ComputeSample"
-    since_value   = "3"
+    since_value   = "1"
   }
   value_function  = "single_value"
 }

--- a/newrelic/validation.go
+++ b/newrelic/validation.go
@@ -42,7 +42,7 @@ func intInSlice(valid []int) schema.SchemaValidateFunc {
 	}
 }
 
-func StringIntBetween(min, max int) schema.SchemaValidateFunc {
+func stringIntBetween(min, max int) schema.SchemaValidateFunc {
 	return func(i interface{}, k string) (s []string, es []error) {
 		v, ok := i.(string)
 		if !ok {

--- a/newrelic/validation.go
+++ b/newrelic/validation.go
@@ -2,8 +2,8 @@ package newrelic
 
 import (
 	"fmt"
-
 	"github.com/hashicorp/terraform/helper/schema"
+	"strconv"
 )
 
 func float64Gte(gte float64) schema.SchemaValidateFunc {
@@ -38,6 +38,29 @@ func intInSlice(valid []int) schema.SchemaValidateFunc {
 		}
 
 		es = append(es, fmt.Errorf("expected %s to be one of %v, got %v", k, valid, v))
+		return
+	}
+}
+
+func StringIntBetween(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		intValue, err := strconv.Atoi(v)
+		if err != nil {
+			es = append(es, fmt.Errorf("expected %s to be convertable to int, got %s", k, v))
+			return
+		}
+
+		if intValue < min || intValue > max {
+			es = append(es, fmt.Errorf("expected %s to be in the range (%d - %d), got %s", k, min, max, v))
+			return
+		}
+
 		return
 	}
 }

--- a/newrelic/validation_test.go
+++ b/newrelic/validation_test.go
@@ -13,6 +13,34 @@ type testCase struct {
 	expectedErr *regexp.Regexp
 }
 
+func TestValidationIntBetweenStrings(t *testing.T) {
+	runTestCases(t, []testCase{
+		{
+			val: "1",
+			f:   StringIntBetween(1, 3),
+		},
+		{
+			val: "3",
+			f:   StringIntBetween(1, 3),
+		},
+		{
+			val:         "notanumber",
+			f:           StringIntBetween(1, 3),
+			expectedErr: regexp.MustCompile("expected [\\w]+ to be convertable to int, got notanumber"),
+		},
+		{
+			val:         2,
+			f:           StringIntBetween(1, 3),
+			expectedErr: regexp.MustCompile("expected type of [\\w]+ to be string"),
+		},
+		{
+			val:         "4",
+			f:           StringIntBetween(1, 3),
+			expectedErr: regexp.MustCompile("expected [\\w]+ to be in the range \\(1 - 3\\), got 4"),
+		},
+	})
+}
+
 func TestValidationIntInInSlice(t *testing.T) {
 	runTestCases(t, []testCase{
 		{

--- a/newrelic/validation_test.go
+++ b/newrelic/validation_test.go
@@ -17,25 +17,25 @@ func TestValidationIntBetweenStrings(t *testing.T) {
 	runTestCases(t, []testCase{
 		{
 			val: "1",
-			f:   StringIntBetween(1, 3),
+			f:   stringIntBetween(1, 3),
 		},
 		{
 			val: "3",
-			f:   StringIntBetween(1, 3),
+			f:   stringIntBetween(1, 3),
 		},
 		{
 			val:         "notanumber",
-			f:           StringIntBetween(1, 3),
+			f:           stringIntBetween(1, 3),
 			expectedErr: regexp.MustCompile("expected [\\w]+ to be convertable to int, got notanumber"),
 		},
 		{
 			val:         2,
-			f:           StringIntBetween(1, 3),
+			f:           stringIntBetween(1, 3),
 			expectedErr: regexp.MustCompile("expected type of [\\w]+ to be string"),
 		},
 		{
 			val:         "4",
-			f:           StringIntBetween(1, 3),
+			f:           stringIntBetween(1, 3),
 			expectedErr: regexp.MustCompile("expected [\\w]+ to be in the range \\(1 - 3\\), got 4"),
 		},
 	})

--- a/newrelic/validation_test.go
+++ b/newrelic/validation_test.go
@@ -103,7 +103,7 @@ func runTestCases(t *testing.T, cases []testCase) {
 		}
 
 		if !matchErr(errs, tc.expectedErr) {
-			t.Fatalf("expected test case %d to produce error matching \"%s\", got %v", i, tc.expectedErr, errs)
+			t.Fatalf("expected test case %d to produce error matching \"%s\", got '%v'", i, tc.expectedErr, errs[0])
 		}
 	}
 }

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 
 The `term` mapping supports the following arguments:
 
-  * `duration` - (Required) In minutes, must be: `1`, `2`, `3`, `4`, `5`, `10`, `15`, `30`, `60`, or `120`.
+  * `duration` - (Required) Query duration in minutes.
   * `operator` - (Optional) `above`, `below`, or `equal`.  Defaults to `equal`.
   * `priority` - (Optional) `critical` or `warning`.  Defaults to `critical`.
   * `threshold` - (Required) Must be 0 or greater.

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -66,7 +66,7 @@ The `term` mapping supports the following arguments:
 The `nrql` attribute supports the following arguments:
 
   * `query` - (Required) The NRQL query to execute for the condition.
-  * `since_value` - (Required) The value to be used in the `SINCE <X> MINUTES AGO` clause for the NRQL query. Must be: `1`, `2`, `3`, `4`, or `5`.
+  * `since_value` - (Required) The value to be used in the `SINCE <X> MINUTES AGO` clause for the NRQL query. Must be integer between `1` and `20` (inclusive).
 
 ## Attributes Reference
 


### PR DESCRIPTION
NRQL condition limitations for `duration` and `since_value` terms are previously overly strict and limiting out values that were perfectly acceptable for the API.

`duration` is previously limiting to one of 1, 2, 3, 4, 5, 10, 15, 30, 60, or 120, but the API has no such restriction and only requires that it is a positive integer

`since_value` is limited to "1", "2", "3", "4",  or "5", but the API allows any value between 1 and 20.

This PR relaxes limitations on the term validation to more accurately reflect the limitations imposed by the API.