### PR TITLE
Modifies since_value's validation to match rest API's requirements

### DIFF
--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -55,7 +55,7 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 							Required: true,
 							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 								valueString := val.(string)
-								val, err := strconv.Atoi(valueString)
+								v, err := strconv.Atoi(valueString)
 								if err != nil {
 									errs = append(errs, fmt.Errorf("Error converting string to int: %#v", err))
 								}

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -52,14 +52,22 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 						"since_value": {
 							Type:     schema.TypeString,
 							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10",
-								"11", "12", "13", "14", "15", "16", "17", "18", "19", "20"}, false),
+							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+								v, err := strconv.Atoi(val)
+								if err != nil {
+									errs = append(errs, fmt.Errorf("%q Error converting string to int: %#v", key, err)
+								}
+   								if v < 1 || v > 20 {
+     								errs = append(errs, fmt.Errorf("%q must be between 0 and 20 inclusive, got: %d", key, v))
+								}
+								return
+							},
 						},
 					},
 				},
 			},
 			"term": {
-				Type: schema.TypeList,
+				Type: schema.TypeList,s
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"duration": {

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -50,9 +50,10 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 							Required: true,
 						},
 						"since_value": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.IntBetween(1, 20),
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10",
+								"11", "12", "13", "14", "15", "16", "17", "18", "19", "20"}, false),
 						},
 					},
 				},

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -54,7 +54,8 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-								v, err := strconv.Atoi(val)
+								valueString := val.(string)
+								val, err := strconv.Atoi(valueString)
 								if err != nil {
 									errs = append(errs, fmt.Errorf("Error converting string to int: %#v", err))
 								}

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -3,6 +3,7 @@ package newrelic
 import (
 	"fmt"
 	"log"
+	"strconv"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -55,10 +56,10 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 								v, err := strconv.Atoi(val)
 								if err != nil {
-									errs = append(errs, fmt.Errorf("%q Error converting string to int: %#v", key, err)
+									errs = append(errs, fmt.Errorf("Error converting string to int: %#v", err))
 								}
-   								if v < 1 || v > 20 {
-     								errs = append(errs, fmt.Errorf("%q must be between 0 and 20 inclusive, got: %d", key, v))
+								if v < 1 || v > 20 {
+									errs = append(errs, fmt.Errorf("%q must be between 0 and 20 inclusive, got: %d", key, v))
 								}
 								return
 							},
@@ -67,7 +68,7 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 				},
 			},
 			"term": {
-				Type: schema.TypeList,s
+				Type: schema.TypeList,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"duration": {

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -52,7 +52,7 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 						"since_value": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"1", "2", "3", "4", "5"}, false),
+							ValidateFunc: validation.IntBetween(1, 20),
 						},
 					},
 				},

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -43,7 +43,7 @@ func TestAccNewRelicNrqlAlertCondition_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"newrelic_nrql_alert_condition.foo", "nrql.0.query", "SELECT uniqueCount(hostname) FROM ComputeSample"),
 					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "nrql.0.since_value", "5"),
+						"newrelic_nrql_alert_condition.foo", "nrql.0.since_value", "20"),
 				),
 			},
 			{

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -66,7 +66,7 @@ The `term` mapping supports the following arguments:
 The `nrql` attribute supports the following arguments:
 
   * `query` - (Required) The NRQL query to execute for the condition.
-  * `since_value` - (Required) The value to be used in the `SINCE <X> MINUTES AGO` clause for the NRQL query. Must be: `1`, `2`, `3`, `4`, or `5`.
+  * `since_value` - (Required) The value to be used in the `SINCE <X> MINUTES AGO` clause for the NRQL query. Must be an integer between `1` and `20`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Issue 

The rest API asserts that `since_value` is `the timeframe (in minutes) in which to evaluate the specified NRQL query. since_value must be between 1 and 20.` 
However, the provider does not allow the number to be above `5`. 

## New Relic Documentation 
`nrql[since_value]`  https://docs.newrelic.com/docs/alerts/rest-api-alerts/new-relic-alerts-rest-api/alerts-conditions-api-field-names 

For @SuperBadCode who said he needs it. 
Found out after the fact that it resolves #131 

## Rationale for custom ValidateFunc
It appears as though the newrelic API expects since_value to be a `string` instead of an `int` which prevents the use of [validate.IntBetween](https://godoc.org/github.com/hashicorp/terraform/helper/validation#IntBetween) 