### PR TITLE
Update alert_condition.html.markdown

### DIFF
--- a/website/docs/r/alert_condition.html.markdown
+++ b/website/docs/r/alert_condition.html.markdown
@@ -27,7 +27,8 @@ resource "newrelic_alert_condition" "foo" {
   entities    = ["${data.newrelic_application.app.id}"]
   metric      = "apdex"
   runbook_url = "https://www.example.com"
-
+  condition_scope = "application"
+  
   term {
     duration      = 5
     operator      = "below"


### PR DESCRIPTION
When I do demo follow the example. Run command  `terraform apply` and get  the following message:  
    Error: `condition_scope` must be `application` or `instance`.
It work well after i add a line code `condition_scope = "application"`. I think the example is missing the property `condition_scope` .