### PR TITLE
Fix page title

### DIFF
--- a/website/docs/d/alert_policy.html.markdown
+++ b/website/docs/d/alert_policy.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Looks up the information about an alert policy in New Relic.
 ---
 
-# newrelic\_alert\_channel
+# newrelic\_alert\_policy
 
 Use this data source to get information about an specific alert policy in New Relic which already exists.
 


### PR DESCRIPTION
Page title was incorrectly "newrelic_alert_channel", probably as a result of this file being copied from the one for channels.