### PR TITLE
Fix some failing acceptance tests

### DIFF
--- a/newrelic/resource_newrelic_alert_policy_channel_test.go
+++ b/newrelic/resource_newrelic_alert_policy_channel_test.go
@@ -116,7 +116,7 @@ resource "newrelic_alert_policy_channel" "foo" {
 
 func testAccCheckNewRelicAlertPolicyChannelConfigUpdated(rName string) string {
 	return fmt.Sprintf(`
-resource "newrelic_alert_policy" "bar" {
+resource "newrelic_alert_policy" "foo" {
   name = "tf-test-updated-%[1]s"
 }
 
@@ -131,7 +131,7 @@ resource "newrelic_alert_channel" "foo" {
 }
 
 resource "newrelic_alert_policy_channel" "foo" {
-  policy_id  = "${newrelic_alert_policy.bar.id}"
+  policy_id  = "${newrelic_alert_policy.foo.id}"
   channel_id = "${newrelic_alert_channel.foo.id}"
 }
 `, rName)

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -162,7 +162,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
   }
   nrql {
     query         = "SELECT uniqueCount(hostname) FROM ComputeSample"
-    since_value   = "5"
+    since_value   = "20"
   }
   value_function  = "single_value"
 }


### PR DESCRIPTION
A couple of the acceptance tests were failing.  This PR gets them working again.

### Testing
`NEWRELIC_LICENSE_KEY=<valid_license_key> NEWRELIC_API_KEY=<valid_api_key> make testacc`

### Notes
Sample test output before the fix:
```
=== RUN   TestAccNewRelicAlertChannelDataSource_Basic
--- PASS: TestAccNewRelicAlertChannelDataSource_Basic (5.41s)
=== RUN   TestAccNewRelicAlertPolicyDataSource_Basic
--- PASS: TestAccNewRelicAlertPolicyDataSource_Basic (2.18s)
=== RUN   TestAccNewRelicApplication_Basic
--- PASS: TestAccNewRelicApplication_Basic (1.68s)
=== RUN   TestAccNewRelicSyntheticsMonitorDataSource_Basic
--- PASS: TestAccNewRelicSyntheticsMonitorDataSource_Basic (3.28s)
=== RUN   TestParseIDs_Basic
--- PASS: TestParseIDs_Basic (0.00s)
=== RUN   TestSerializeIDs_Basic
--- PASS: TestSerializeIDs_Basic (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProviderImpl
--- PASS: TestProviderImpl (0.00s)
=== RUN   TestAccNewRelicAlertChannel_Basic
--- PASS: TestAccNewRelicAlertChannel_Basic (4.20s)
=== RUN   TestAccNewRelicAlertChannel_import
--- PASS: TestAccNewRelicAlertChannel_import (2.12s)
=== RUN   TestAccNewRelicAlertCondition_Basic
--- PASS: TestAccNewRelicAlertCondition_Basic (6.20s)
=== RUN   TestAccNewRelicAlertCondition_ZeroThreshold
--- PASS: TestAccNewRelicAlertCondition_ZeroThreshold (3.93s)
=== RUN   TestAccNewRelicAlertCondition_import
--- PASS: TestAccNewRelicAlertCondition_import (5.54s)
=== RUN   TestAccNewRelicAlertCondition_nameGreaterThan64Char
--- PASS: TestAccNewRelicAlertCondition_nameGreaterThan64Char (0.01s)
=== RUN   TestAccNewRelicAlertPolicyChannel_Basic
--- FAIL: TestAccNewRelicAlertPolicyChannel_Basic (3.96s)
    testing.go:568: Step 1 error: errors during apply:
        
        Error: Alerts policy 539027 or channel 2761425 could not be found.
        
        
=== RUN   TestAccNewRelicAlertPolicy_Basic
--- PASS: TestAccNewRelicAlertPolicy_Basic (2.87s)
=== RUN   TestAccNewRelicAlertPolicy_import
--- PASS: TestAccNewRelicAlertPolicy_import (1.86s)
=== RUN   TestAccNewRelicDashboard_Basic
--- PASS: TestAccNewRelicDashboard_Basic (11.20s)
=== RUN   TestAccNewRelicDashboard_import
--- PASS: TestAccNewRelicDashboard_import (6.82s)
=== RUN   TestAccNewRelicInfraAlertCondition_Basic
--- PASS: TestAccNewRelicInfraAlertCondition_Basic (4.48s)
=== RUN   TestAccNewRelicInfraAlertCondition_Where
--- PASS: TestAccNewRelicInfraAlertCondition_Where (2.47s)
=== RUN   TestAccNewRelicInfraAlertCondition_IntegrationProvider
--- SKIP: TestAccNewRelicInfraAlertCondition_IntegrationProvider (0.00s)
    resource_newrelic_infra_alert_condition_test.go:78: Environment variable ENABLE_NEWRELIC_INTEGRATION_PROVIDER is not set
=== RUN   TestAccNewRelicInfraAlertCondition_Thresholds
--- PASS: TestAccNewRelicInfraAlertCondition_Thresholds (4.22s)
=== RUN   TestAccNewRelicNrqlAlertCondition_Basic
--- FAIL: TestAccNewRelicNrqlAlertCondition_Basic (3.99s)
    testing.go:568: Step 0 error: Check failed: Check 13/13 error: newrelic_nrql_alert_condition.foo: Attribute 'nrql.0.since_value' expected "20", got "5"
=== RUN   TestAccNewRelicSyntheticsAlertCondition_Basic
--- PASS: TestAccNewRelicSyntheticsAlertCondition_Basic (8.06s)
=== RUN   TestAccNewRelicSyntheticsMonitorScript_Basic
--- PASS: TestAccNewRelicSyntheticsMonitorScript_Basic (7.69s)
=== RUN   TestAccNewRelicSyntheticsMonitor_Basic
--- PASS: TestAccNewRelicSyntheticsMonitor_Basic (4.05s)
=== RUN   TestValidationIntInInSlice
--- PASS: TestValidationIntInInSlice (0.00s)
=== RUN   TestValidationFloat64Gte
--- PASS: TestValidationFloat64Gte (0.00s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-newrelic/newrelic     96.449s
make: *** [testacc] Error 1
```