### PR TITLE
adding values for type argument to docs

### DIFF
--- a/website/docs/r/synthetics_monitor.html.markdown
+++ b/website/docs/r/synthetics_monitor.html.markdown
@@ -27,7 +27,7 @@ resource "newrelic_synthetics_monitor" "foo" {
 The following arguments are supported:
 
   * `name` - (Required) The title of this monitor.
-  * `type` - (Required) The monitor type.
+  * `type` - (Required) The monitor type (i.e. SIMPLE, BROWSER, SCRIPT_API, SCRIPT_BROWSER).
   * `frequency` - (Required) The interval (in minutes) at which this monitor should run.
   * `status` - (Required) The monitor status (i.e. ENABLED, MUTED, DISABLED)
   * `locations` - (Required) The locations in which this monitor should be run.


### PR DESCRIPTION
I had to check the source to find valid values for the type parameter on `newrelic_synthetics_monitor`.

Valid values found here: https://github.com/terraform-providers/terraform-provider-newrelic/blob/master/newrelic/resource_newrelic_synthetics_monitor.go#L28-L31

Adding values to documentation.