### PR TITLE
Destroy test apps after an acceptance test run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: go
 go:
   - "1.11.x"
+  - "1.12.x"
+  - "1.13.x"
   - tip
 
 env:

--- a/newrelic/data_source_newrelic_alert_channel.go
+++ b/newrelic/data_source_newrelic_alert_channel.go
@@ -53,7 +53,7 @@ func dataSourceNewRelicAlertChannelRead(d *schema.ResourceData, meta interface{}
 	}
 
 	if channel == nil {
-		return fmt.Errorf("The name '%s' does not match any New Relic alert channel.", name)
+		return fmt.Errorf("the name '%s' does not match any New Relic alert channel", name)
 	}
 
 	d.SetId(strconv.Itoa(channel.ID))

--- a/newrelic/data_source_newrelic_alert_policy.go
+++ b/newrelic/data_source_newrelic_alert_policy.go
@@ -56,7 +56,7 @@ func dataSourceNewRelicAlertPolicyRead(d *schema.ResourceData, meta interface{})
 	}
 
 	if policy == nil {
-		return fmt.Errorf("The name '%s' does not match any New Relic alert policy.", name)
+		return fmt.Errorf("the name '%s' does not match any New Relic alert policy", name)
 	}
 
 	d.SetId(strconv.Itoa(policy.ID))

--- a/newrelic/data_source_newrelic_alert_policy_test.go
+++ b/newrelic/data_source_newrelic_alert_policy_test.go
@@ -13,8 +13,9 @@ import (
 func TestAccNewRelicAlertPolicyDataSource_Basic(t *testing.T) {
 	rName := acctest.RandString(5)
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: func(s *terraform.State) error { testAccCheckDestroy(); return nil },
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccNewRelicAlertPolicyDataSourceConfig(rName),

--- a/newrelic/data_source_newrelic_application.go
+++ b/newrelic/data_source_newrelic_application.go
@@ -53,7 +53,7 @@ func dataSourceNewRelicApplicationRead(d *schema.ResourceData, meta interface{})
 	}
 
 	if application == nil {
-		return fmt.Errorf("The name '%s' does not match any New Relic applications.", name)
+		return fmt.Errorf("the name '%s' does not match any New Relic applications", name)
 	}
 
 	d.SetId(strconv.Itoa(application.ID))

--- a/newrelic/data_source_newrelic_application_test.go
+++ b/newrelic/data_source_newrelic_application_test.go
@@ -10,8 +10,9 @@ import (
 
 func TestAccNewRelicApplication_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: func(s *terraform.State) error { testAccCheckDestroy(); return nil },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNewRelicApplicationConfig(),

--- a/newrelic/data_source_newrelic_key_transaction.go
+++ b/newrelic/data_source_newrelic_key_transaction.go
@@ -35,7 +35,7 @@ func dataSourceNewRelicKeyTransactionRead(d *schema.ResourceData, meta interface
 	var transaction *newrelic.KeyTransaction
 	name, ok := d.Get("name").(string)
 	if !ok {
-		return fmt.Errorf("The name '%v' is not a string.", name)
+		return fmt.Errorf("the name '%v' is not a string", name)
 	}
 
 	for _, t := range transactions {
@@ -46,7 +46,7 @@ func dataSourceNewRelicKeyTransactionRead(d *schema.ResourceData, meta interface
 	}
 
 	if transaction == nil {
-		return fmt.Errorf("The name '%s' does not match any New Relic key transaction.", name)
+		return fmt.Errorf("the name '%s' does not match any New Relic key transaction", name)
 	}
 
 	d.SetId(strconv.Itoa(transaction.ID))

--- a/newrelic/data_source_newrelic_synthetics_monitor.go
+++ b/newrelic/data_source_newrelic_synthetics_monitor.go
@@ -59,7 +59,7 @@ func dataSourceNewRelicSyntheticsMonitorRead(d *schema.ResourceData, meta interf
 	}
 
 	if monitor == nil {
-		return fmt.Errorf("The name '%s' does not match any New Relic monitors.", name)
+		return fmt.Errorf("the name '%s' does not match any New Relic monitors", name)
 	}
 
 	d.SetId(monitor.ID)

--- a/newrelic/data_source_newrelic_synthetics_monitor_test.go
+++ b/newrelic/data_source_newrelic_synthetics_monitor_test.go
@@ -15,8 +15,9 @@ var (
 
 func TestAccNewRelicSyntheticsMonitorDataSource_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: func(s *terraform.State) error { testAccCheckDestroy(); return nil },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckNewRelicSyntheticsDataSourceConfig(expectedMonitorName),

--- a/newrelic/resource_newrelic_alert_channel_test.go
+++ b/newrelic/resource_newrelic_alert_channel_test.go
@@ -71,6 +71,8 @@ func TestAccNewRelicAlertChannel_import(t *testing.T) {
 }
 
 func testAccCheckNewRelicAlertChannelDestroy(s *terraform.State) error {
+	defer testAccCheckDestroy()
+
 	client := testAccProvider.Meta().(*ProviderConfig).Client
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "newrelic_alert_channel" {

--- a/newrelic/resource_newrelic_alert_condition_test.go
+++ b/newrelic/resource_newrelic_alert_condition_test.go
@@ -150,6 +150,8 @@ func TestAccNewRelicAlertCondition_nameGreaterThan64Char(t *testing.T) {
 }
 
 func testAccCheckNewRelicAlertConditionDestroy(s *terraform.State) error {
+	defer testAccCheckDestroy()
+
 	client := testAccProvider.Meta().(*ProviderConfig).Client
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "newrelic_alert_condition" {

--- a/newrelic/resource_newrelic_alert_policy_channel_test.go
+++ b/newrelic/resource_newrelic_alert_policy_channel_test.go
@@ -33,6 +33,8 @@ func TestAccNewRelicAlertPolicyChannel_Basic(t *testing.T) {
 }
 
 func testAccCheckNewRelicAlertPolicyChannelDestroy(s *terraform.State) error {
+	defer testAccCheckDestroy()
+
 	client := testAccProvider.Meta().(*ProviderConfig).Client
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "newrelic_alert_policy_channel" {

--- a/newrelic/resource_newrelic_alert_policy_test.go
+++ b/newrelic/resource_newrelic_alert_policy_test.go
@@ -64,6 +64,8 @@ func TestAccNewRelicAlertPolicy_import(t *testing.T) {
 }
 
 func testAccCheckNewRelicAlertPolicyDestroy(s *terraform.State) error {
+	defer testAccCheckDestroy()
+
 	client := testAccProvider.Meta().(*ProviderConfig).Client
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "newrelic_alert_policy" {

--- a/newrelic/resource_newrelic_dashboard_test.go
+++ b/newrelic/resource_newrelic_dashboard_test.go
@@ -121,6 +121,8 @@ func TestAccNewRelicDashboard_import(t *testing.T) {
 }
 
 func testAccCheckNewRelicDashboardDestroy(s *terraform.State) error {
+	defer testAccCheckDestroy()
+
 	client := testAccProvider.Meta().(*ProviderConfig).Client
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "newrelic_dashboard" {

--- a/newrelic/resource_newrelic_infra_alert_condition_test.go
+++ b/newrelic/resource_newrelic_infra_alert_condition_test.go
@@ -152,6 +152,8 @@ func TestAccNewRelicInfraAlertCondition_Thresholds(t *testing.T) {
 }
 
 func testAccCheckNewRelicInfraAlertConditionDestroy(s *terraform.State) error {
+	defer testAccCheckDestroy()
+
 	client := testAccProvider.Meta().(*ProviderConfig).InfraClient
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "newrelic_infra_alert_condition" {

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -83,6 +83,8 @@ func TestAccNewRelicNrqlAlertCondition_Basic(t *testing.T) {
 // TODO: func_ TestAccNewRelicNrqlAlertCondition_Multi(t *testing.T) {
 
 func testAccCheckNewRelicNrqlAlertConditionDestroy(s *terraform.State) error {
+	defer testAccCheckDestroy()
+
 	client := testAccProvider.Meta().(*ProviderConfig).Client
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "newrelic_nrql_alert_condition" {

--- a/newrelic/resource_newrelic_synthetics_alert_condition_test.go
+++ b/newrelic/resource_newrelic_synthetics_alert_condition_test.go
@@ -45,6 +45,8 @@ func TestAccNewRelicSyntheticsAlertCondition_Basic(t *testing.T) {
 }
 
 func testAccCheckNewRelicSyntheticsAlertConditionDestroy(s *terraform.State) error {
+	defer testAccCheckDestroy()
+
 	client := testAccProvider.Meta().(*ProviderConfig).Client
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "newrelic_synthetics_alert_condition" {

--- a/newrelic/resource_newrelic_synthetics_monitor.go
+++ b/newrelic/resource_newrelic_synthetics_monitor.go
@@ -99,9 +99,9 @@ func buildSyntheticsMonitorStruct(d *schema.ResourceData) *synthetics.CreateMoni
 		monitor.URI = uri.(string)
 	}
 
-	locations_raw := d.Get("locations").(*schema.Set)
-	locations := make([]string, locations_raw.Len())
-	for i, v := range locations_raw.List() {
+	locationsRaw := d.Get("locations").(*schema.Set)
+	locations := make([]string, locationsRaw.Len())
+	for i, v := range locationsRaw.List() {
 		locations[i] = fmt.Sprint(v)
 	}
 
@@ -137,9 +137,9 @@ func buildSyntheticsUpdateMonitorArgs(d *schema.ResourceData) *synthetics.Update
 		monitor.URI = uri.(string)
 	}
 
-	locations_raw := d.Get("locations").(*schema.Set)
-	locations := make([]string, locations_raw.Len())
-	for i, v := range locations_raw.List() {
+	locationsRaw := d.Get("locations").(*schema.Set)
+	locations := make([]string, locationsRaw.Len())
+	for i, v := range locationsRaw.List() {
 		locations[i] = fmt.Sprint(v)
 	}
 

--- a/newrelic/resource_newrelic_synthetics_monitor_script_test.go
+++ b/newrelic/resource_newrelic_synthetics_monitor_script_test.go
@@ -66,6 +66,8 @@ func testAccCheckNewRelicSyntheticsMonitorScriptExists(n string) resource.TestCh
 }
 
 func testAccCheckNewRelicSyntheticsMonitorScriptDestroy(s *terraform.State) error {
+	defer testAccCheckDestroy()
+
 	client := testAccProvider.Meta().(*ProviderConfig).Synthetics
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "newrelic_synthetics_monitor_script" {

--- a/newrelic/resource_newrelic_synthetics_monitor_test.go
+++ b/newrelic/resource_newrelic_synthetics_monitor_test.go
@@ -82,6 +82,8 @@ func testAccCheckNewRelicSyntheticsMonitorExists(n string) resource.TestCheckFun
 }
 
 func testAccCheckNewRelicSyntheticsMonitorDestroy(s *terraform.State) error {
+	defer testAccCheckDestroy()
+
 	client := testAccProvider.Meta().(*ProviderConfig).Synthetics
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "newrelic_synthetics_monitor" {


### PR DESCRIPTION
This PR cleans up the fake applications created after a run of the acceptance tests.

It also adds Go 1.12.x and 1.13.x to the Travis build and resolves some linting issues.