### PR TITLE
fix issue #165 with strict name matching for alert policies

### DIFF
--- a/newrelic/data_source_newrelic_alert_channel.go
+++ b/newrelic/data_source_newrelic_alert_channel.go
@@ -46,7 +46,7 @@ func dataSourceNewRelicAlertChannelRead(d *schema.ResourceData, meta interface{}
 	name := d.Get("name").(string)
 
 	for _, c := range channels {
-		if strings.Contains(strings.ToLower(c.Name), strings.ToLower(name)) {
+		if strings.EqualFold(c.Name, name) {
 			channel = &c
 			break
 		}

--- a/newrelic/data_source_newrelic_alert_channel_test.go
+++ b/newrelic/data_source_newrelic_alert_channel_test.go
@@ -57,7 +57,7 @@ func testAccNewRelicAlertChannel(n string) resource.TestCheckFunc {
 			return fmt.Errorf("expected to get an alert channel from New Relic")
 		}
 
-		if strings.Contains(strings.ToLower(testAccExpectedAlertChannelName), strings.ToLower(a["name"])) {
+		if strings.EqualFold(testAccExpectedAlertChannelName, a["name"]) {
 			return fmt.Errorf("expected the alert channel name to be: %s, but got: %s", testAccExpectedAlertChannelName, a["name"])
 		}
 

--- a/newrelic/data_source_newrelic_alert_policy.go
+++ b/newrelic/data_source_newrelic_alert_policy.go
@@ -46,6 +46,7 @@ func dataSourceNewRelicAlertPolicyRead(d *schema.ResourceData, meta interface{})
 	}
 
 	var policy *newrelic.AlertPolicy
+
 	name := d.Get("name").(string)
 
 	for _, c := range policies {

--- a/newrelic/data_source_newrelic_alert_policy.go
+++ b/newrelic/data_source_newrelic_alert_policy.go
@@ -49,7 +49,7 @@ func dataSourceNewRelicAlertPolicyRead(d *schema.ResourceData, meta interface{})
 	name := d.Get("name").(string)
 
 	for _, c := range policies {
-		if strings.Contains(strings.ToLower(c.Name), strings.ToLower(name)) {
+		if strings.EqualFold(c.Name, name) {
 			policy = &c
 			break
 		}

--- a/newrelic/data_source_newrelic_alert_policy_test.go
+++ b/newrelic/data_source_newrelic_alert_policy_test.go
@@ -57,7 +57,7 @@ func testAccCheckNewRelicAlertPolicyDataSource(n string) resource.TestCheckFunc 
 			return fmt.Errorf("expected to get an alert policy from New Relic")
 		}
 
-		if strings.Contains(strings.ToLower(testAccExpectedAlertPolicyName), strings.ToLower(a["name"])) {
+		if strings.EqualFold(testAccExpectedAlertPolicyName, a["name"]) {
 			return fmt.Errorf("expected the alert policy name to be: %s, but got: %s", testAccExpectedAlertPolicyName, a["name"])
 		}
 


### PR DESCRIPTION
A possible fix for #165 .

- Implements a stricter matching on alert policy data sources. 
