### PR TITLE
[WIP] add Violation Close timer for NRQL Alert Conditions

### DIFF
--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -47,9 +47,9 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 				Optional: true,
 			},
 			"violation_time_limit_seconds": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "This limit will automatically force-close a long-lasting violation after the number of hours you select",
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntInSlice([]int{3600, 7200, 14400, 28800, 43200, 86400}),
 			},
 			"nrql": {
 				Type:     schema.TypeList,
@@ -203,6 +203,7 @@ func readNrqlAlertConditionStruct(condition *newrelic.AlertNrqlCondition, d *sch
 	d.Set("type", condition.Type)
 	d.Set("expected_groups", condition.ExpectedGroups)
 	d.Set("ignore_overlap", condition.IgnoreOverlap)
+	d.Set("violation_time_limit_seconds", condition.ViolationCloseTimer)
 
 	if condition.ValueFunction == "" {
 		d.Set("value_function", "single_value")

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -46,6 +46,11 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"violation_time_limit_seconds": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "This limit will automatically force-close a long-lasting violation after the number of hours you select",
+			},
 			"nrql": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -154,13 +159,14 @@ func buildNrqlAlertConditionStruct(d *schema.ResourceData) *newrelic.AlertNrqlCo
 	}
 
 	condition := newrelic.AlertNrqlCondition{
-		Name:          d.Get("name").(string),
-		Type:          d.Get("type").(string),
-		Enabled:       d.Get("enabled").(bool),
-		Terms:         terms,
-		PolicyID:      d.Get("policy_id").(int),
-		Nrql:          query,
-		ValueFunction: d.Get("value_function").(string),
+		Name:                d.Get("name").(string),
+		Type:                d.Get("type").(string),
+		Enabled:             d.Get("enabled").(bool),
+		Terms:               terms,
+		PolicyID:            d.Get("policy_id").(int),
+		Nrql:                query,
+		ValueFunction:       d.Get("value_function").(string),
+		ViolationCloseTimer: d.Get("violation_time_limit_seconds").(int),
 	}
 
 	if attr, ok := d.GetOk("runbook_url"); ok {
@@ -169,6 +175,10 @@ func buildNrqlAlertConditionStruct(d *schema.ResourceData) *newrelic.AlertNrqlCo
 
 	if attr, ok := d.GetOkExists("ignore_overlap"); ok {
 		condition.IgnoreOverlap = attr.(bool)
+	}
+
+	if attr, ok := d.GetOkExists("violation_time_limit_seconds"); ok {
+		condition.ViolationCloseTimer = attr.(int)
 	}
 
 	if attr, ok := d.GetOk("expected_groups"); ok {

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -167,6 +167,8 @@ resource "newrelic_nrql_alert_condition" "foo" {
   name            = "tf-test-%[1]s"
   runbook_url     = "https://foo.example.com"
   enabled         = false
+  violation_time_limit_seconds = 3600
+
 
   term {
     duration      = 5
@@ -198,6 +200,8 @@ resource "newrelic_nrql_alert_condition" "foo" {
   name            = "tf-test-updated-%[1]s"
   runbook_url     = "https://bar.example.com"
   enabled         = false
+  violation_time_limit_seconds = 3600
+
 
   term {
     duration      = 10
@@ -226,6 +230,8 @@ resource "newrelic_nrql_alert_condition" "foo" {
   name            = "tf-test-updated-%[1]s"
   runbook_url     = "https://bar.example.com"
   enabled         = false
+  violation_time_limit_seconds = 7200
+
 
   term {
     duration      = 10

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -56,6 +56,7 @@ The following arguments are supported:
 - `value_function` - (Optional) Possible values are `single_value`, `sum`.
 - `expected_groups` - (Optional) Number of expected groups when using `outlier` detection.
 - `ignore_overlap` - (Optional) Whether to look for a convergence of groups when using `outlier` detection.
+- `violation_time_limit_seconds` - (Optional) Sets a time limit, in seconds, that will automatically force-close a long-lasting violation after the time limit you select.  Possible values are `3600`, `7200`, `14400`, `28800`, `43200`, and `86400`.
 
 ## Terms
 


### PR DESCRIPTION
Work in Progress. Blocked by https://github.com/paultyng/go-newrelic/pull/75.

A possible fix for https://github.com/terraform-providers/terraform-provider-newrelic/issues/157.

1. Adds `violation_limit_time_seconds` to NRQL Alerts Conditions to reflect updates to the New Relic API (see [documentation](https://docs.newrelic.com/docs/alerts/new-relic-alerts/reviewing-alert-incidents/how-alert-condition-violations-are-closed#time-limit) and [API details](https://rpm.newrelic.com/api/explore/alerts_nrql_conditions/list)).
2. Updates related tests. 

cc. @ctrombley 