### PR TITLE
fix: align alert condition duration constraints to NR's API constraints

### DIFF
--- a/newrelic/resource_newrelic_alert_condition.go
+++ b/newrelic/resource_newrelic_alert_condition.go
@@ -138,7 +138,7 @@ func resourceNewRelicAlertCondition() *schema.Resource {
 						"duration": {
 							Type:         schema.TypeInt,
 							Required:     true,
-							ValidateFunc: intInSlice([]int{5, 10, 15, 30, 60, 120}),
+							ValidateFunc: validation.IntBetween(5, 120),
 						},
 						"operator": {
 							Type:         schema.TypeString,

--- a/newrelic/resource_newrelic_alert_condition_test.go
+++ b/newrelic/resource_newrelic_alert_condition_test.go
@@ -286,7 +286,7 @@ resource "newrelic_alert_condition" "foo" {
   policy_id = "${newrelic_alert_policy.foo.id}"
 
   name            = "tf-test-updated-%[1]s"
-  enabled         = true  
+  enabled         = true
   type            = "apm_app_metric"
   entities        = ["${data.newrelic_application.app.id}"]
   metric          = "apdex"
@@ -318,7 +318,7 @@ resource "newrelic_alert_condition" "foo" {
   policy_id = "${newrelic_alert_policy.foo.id}"
 
   name            = "tf-test-%[1]s"
-  enabled         = false  
+  enabled         = false
   type            = "apm_app_metric"
   entities        = ["${data.newrelic_application.app.id}"]
   metric          = "apdex"
@@ -396,6 +396,90 @@ resource "newrelic_alert_condition" "foo" {
   condition_scope = "application"
   term {
     duration      = 5
+    operator      = "below"
+    priority      = "critical"
+    threshold     = "0.75"
+    time_function = "all"
+  }
+}
+`
+}
+
+func TestErrorThrownUponConditionTermDurationGreaterThan120(t *testing.T) {
+	expectedErrorMsg, _ := regexp.Compile(`expected term.0.duration to be in the range \(5 - 120\)`)
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testErrorThrownUponConditionTermDurationGreaterThan120(),
+				ExpectError: expectedErrorMsg,
+			},
+		},
+	})
+}
+
+func testErrorThrownUponConditionTermDurationGreaterThan120() string {
+	return `
+provider "newrelic" {
+  api_key = "foo"
+}
+
+resource "newrelic_alert_policy" "foo" {
+  name = "tf-test-%[1]s"
+}
+resource "newrelic_alert_condition" "foo" {
+  policy_id = "${newrelic_alert_policy.foo.id}"
+  name            = "test-term-duration"
+  type            = "apm_app_metric"
+  entities        = ["12345"]
+  metric          = "apdex"
+  runbook_url     = "https://foo.example.com"
+  condition_scope = "application"
+  term {
+    duration      = 121
+    operator      = "below"
+    priority      = "critical"
+    threshold     = "0.75"
+    time_function = "all"
+  }
+}
+`
+}
+
+func TestErrorThrownUponConditionTermDurationLessThan5(t *testing.T) {
+	expectedErrorMsg, _ := regexp.Compile(`expected term.0.duration to be in the range \(5 - 120\)`)
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testErrorThrownUponConditionTermDurationLessThan5(),
+				ExpectError: expectedErrorMsg,
+			},
+		},
+	})
+}
+
+func testErrorThrownUponConditionTermDurationLessThan5() string {
+	return `
+provider "newrelic" {
+  api_key = "foo"
+}
+
+resource "newrelic_alert_policy" "foo" {
+  name = "tf-test-%[1]s"
+}
+resource "newrelic_alert_condition" "foo" {
+  policy_id = "${newrelic_alert_policy.foo.id}"
+  name            = "test-term-duration"
+  type            = "apm_app_metric"
+  entities        = ["12345"]
+  metric          = "apdex"
+  runbook_url     = "https://foo.example.com"
+  condition_scope = "application"
+  term {
+    duration      = 4
     operator      = "below"
     priority      = "critical"
     threshold     = "0.75"

--- a/website/docs/r/alert_condition.html.markdown
+++ b/website/docs/r/alert_condition.html.markdown
@@ -28,7 +28,7 @@ resource "newrelic_alert_condition" "foo" {
   metric      = "apdex"
   runbook_url = "https://www.example.com"
   condition_scope = "application"
-  
+
   term {
     duration      = 5
     operator      = "below"
@@ -60,7 +60,7 @@ The following arguments are supported:
 
 The `term` mapping supports the following arguments:
 
-  * `duration` - (Required) In minutes, must be: `5`, `10`, `15`, `30`, `60`, or `120`.
+  * `duration` - (Required) In minutes, must be in the range of `5` to `120`, inclusive.
   * `operator` - (Optional) `above`, `below`, or `equal`.  Defaults to `equal`.
   * `priority` - (Optional) `critical` or `warning`.  Defaults to `critical`.
   * `threshold` - (Required) Must be 0 or greater.


### PR DESCRIPTION
Fixes: #201