### PR TITLE
Document type arg

### DIFF
--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -52,6 +52,8 @@ The following arguments are supported:
 - `term` - (Required) A list of terms for this condition. See [Terms](#terms) below for details.
 - `nrql` - (Required) A NRQL query. See [NRQL](#nrql) below for details.
 - `value_function` - (Optional) Possible values are `single_value`, `sum`.
+- `expected_groups` - (Optional) Number of expected groups when using `outlier` detection.
+- `ignore_overlap` - (Optional) Whether to look for a convergence of groups when using `outlier` detection.
 
 ## Terms
 

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -19,6 +19,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
   policy_id = "${newrelic_alert_policy.foo.id}"
 
   name        = "foo"
+  type        = "static"
   runbook_url = "https://www.example.com"
   enabled     = true
 
@@ -45,6 +46,7 @@ The following arguments are supported:
 
 - `policy_id` - (Required) The ID of the policy where this condition should be used.
 - `name` - (Required) The title of the condition
+- `type` - (Optional) The type of the condition. One of `static`, `outlier`, or `baseline`. Defaults to `static`.
 - `runbook_url` - (Optional) Runbook URL to display in notifications.
 - `enabled` - (Optional) Set whether to enable the alert condition. Defaults to `true`.
 - `term` - (Required) A list of terms for this condition. See [Terms](#terms) below for details.


### PR DESCRIPTION
Support for different `type` args was added in #141 (Issue #50) but the docs need to be updated as well. This documents the possible values for `type`. 