### PR TITLE
feat: add import newrelic_alert_policy data source, newrelic_alert_policy acceptance test updates

### DIFF
--- a/newrelic/data_source_newrelic_alert_policy.go
+++ b/newrelic/data_source_newrelic_alert_policy.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	newrelic "github.com/paultyng/go-newrelic/v4/api"
@@ -13,7 +14,6 @@ import (
 func dataSourceNewRelicAlertPolicy() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceNewRelicAlertPolicyRead,
-
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -59,11 +59,17 @@ func dataSourceNewRelicAlertPolicyRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("the name '%s' does not match any New Relic alert policy", name)
 	}
 
+	// New Relic provides created_at and updated_at as millisecond unix timestamps
+	// https://www.terraform.io/docs/extend/schemas/schema-types.html#date-amp-time-data
+	// "TypeString is also used for date/time data, the preferred format is RFC 3339."
+	created := unixMillis(policy.CreatedAt).Format(time.RFC3339)
+	updated := unixMillis(policy.UpdatedAt).Format(time.RFC3339)
+
 	d.SetId(strconv.Itoa(policy.ID))
 	d.Set("name", policy.Name)
 	d.Set("incident_preference", policy.IncidentPreference)
-	d.Set("created_at", policy.CreatedAt)
-	d.Set("updated_at", policy.UpdatedAt)
+	d.Set("created_at", created)
+	d.Set("updated_at", updated)
 
 	return nil
 }

--- a/newrelic/resource_newrelic_alert_policy_test.go
+++ b/newrelic/resource_newrelic_alert_policy_test.go
@@ -86,7 +86,7 @@ func TestAccNewRelicAlertPolicy_ResourceNotFound(t *testing.T) {
 	})
 }
 
-func TestNewRelicAlertPolicy_ErrorThrownWhenNameEmpty(t *testing.T) {
+func TestAccNewRelicAlertPolicy_ErrorThrownWhenNameEmpty(t *testing.T) {
 	expectedErrorMsg, _ := regexp.Compile(`name must not be empty`)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/newrelic/resource_newrelic_alert_policy_test.go
+++ b/newrelic/resource_newrelic_alert_policy_test.go
@@ -2,10 +2,9 @@ package newrelic
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"testing"
-
-	"regexp"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -13,49 +12,33 @@ import (
 )
 
 func TestAccNewRelicAlertPolicy_Basic(t *testing.T) {
-	rName := acctest.RandString(5)
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNewRelicAlertPolicyDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckNewRelicAlertPolicyConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicAlertPolicyExists("newrelic_alert_policy.foo"),
-					resource.TestCheckResourceAttr(
-						"newrelic_alert_policy.foo", "name", fmt.Sprintf("tf-test-%s", rName)),
-					resource.TestCheckResourceAttr(
-						"newrelic_alert_policy.foo", "incident_preference", "PER_POLICY"),
-				),
-			},
-			{
-				Config: testAccCheckNewRelicAlertPolicyConfigUpdated(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicAlertPolicyExists("newrelic_alert_policy.foo"),
-					resource.TestCheckResourceAttr(
-						"newrelic_alert_policy.foo", "name", fmt.Sprintf("tf-test-updated-%s", rName)),
-					resource.TestCheckResourceAttr(
-						"newrelic_alert_policy.foo", "incident_preference", "PER_CONDITION"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccNewRelicAlertPolicy(t *testing.T) {
 	resourceName := "newrelic_alert_policy.foo"
 	rName := acctest.RandString(5)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicAlertPolicyDestroy,
 		Steps: []resource.TestStep{
+			// Test: Create
 			{
-				Config: testAccCheckNewRelicAlertPolicyConfig(rName),
+				Config: testAccNewRelicAlertPolicyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAlertPolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-test-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "incident_preference", "PER_POLICY"),
+				),
 			},
-
+			// Test: Update
+			{
+				Config: testAccNewRelicAlertPolicyConfigUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAlertPolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-test-updated-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "incident_preference", "PER_CONDITION"),
+				),
+			},
+			// Test: Import
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -63,6 +46,76 @@ func TestAccNewRelicAlertPolicy(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccNewRelicAlertPolicy_NoDiffOnReapply(t *testing.T) {
+	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNewRelicAlertPolicyConfig(rName),
+			},
+			{
+				Config:             testAccNewRelicAlertPolicyConfig(rName),
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestAccNewRelicAlertPolicy_ResourceNotFound(t *testing.T) {
+	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNewRelicAlertPolicyConfig(rName),
+			},
+			{
+				PreConfig: testAccDeleteAlertPolicy(rName),
+				Config:    testAccNewRelicAlertPolicyConfig(rName),
+			},
+		},
+	})
+}
+
+func TestNewRelicAlertPolicy_ErrorThrownWhenNameEmpty(t *testing.T) {
+	expectedErrorMsg, _ := regexp.Compile(`name must not be empty`)
+
+	resource.ParallelTest(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAlertPolicyConfigNameEmpty(),
+				ExpectError: expectedErrorMsg,
+			},
+		},
+	})
+}
+
+func testAccNewRelicAlertPolicyConfig(name string) string {
+	return fmt.Sprintf(`
+resource "newrelic_alert_policy" "foo" {
+  name = "tf-test-%s"
+}
+`, name)
+}
+
+func testAccNewRelicAlertPolicyConfigUpdated(rName string) string {
+	return fmt.Sprintf(`
+resource "newrelic_alert_policy" "foo" {
+  name                = "tf-test-updated-%s"
+  incident_preference = "PER_CONDITION"
+}
+`, rName)
 }
 
 func testAccCheckNewRelicAlertPolicyDestroy(s *terraform.State) error {
@@ -117,42 +170,22 @@ func testAccCheckNewRelicAlertPolicyExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckNewRelicAlertPolicyConfig(rName string) string {
-	return fmt.Sprintf(`
-resource "newrelic_alert_policy" "foo" {
-  name = "tf-test-%s"
-}
-`, rName)
+func testAccDeleteAlertPolicy(name string) func() {
+	return func() {
+		client := testAccProvider.Meta().(*ProviderConfig).Client
+		alertPolicies, _ := client.ListAlertPolicies()
+
+		for _, d := range alertPolicies {
+			if d.Name == name {
+				_ = client.DeleteAlertPolicy(d.ID)
+				break
+			}
+		}
+	}
 }
 
-func testAccCheckNewRelicAlertPolicyConfigUpdated(rName string) string {
-	return fmt.Sprintf(`
-resource "newrelic_alert_policy" "foo" {
-  name                = "tf-test-updated-%s"
-  incident_preference = "PER_CONDITION"
-}
-`, rName)
-}
-
-func TestErrorThrownUponPolicyNameLessThan1Char(t *testing.T) {
-	expectedErrorMsg, _ := regexp.Compile(`name must not be empty`)
-	resource.Test(t, resource.TestCase{
-		IsUnitTest: true,
-		Providers:  testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testErrorThrownUponPolicyNameLessThan1Char(),
-				ExpectError: expectedErrorMsg,
-			},
-		},
-	})
-}
-
-func testErrorThrownUponPolicyNameLessThan1Char() string {
+func testAlertPolicyConfigNameEmpty() string {
 	return `
-provider "newrelic" {
-  api_key = "foo"
-}
 resource "newrelic_alert_policy" "foo" {
   name = ""
 }


### PR DESCRIPTION
Fixes: #213 

**Tests**
- Adjust tests to follow conventions
- Add additional test cases for Alert Policies

**Improvements**
- Add ability to import `newrelic_alert_policy` data source