### PR TITLE
fix: appease linter

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -13,7 +13,7 @@ BUILD_DIR    := ./bin/
 COVERAGE_DIR := ./coverage/
 COVERMODE     = atomic
 
-default: clean build lint vet test cover-report
+default: clean build lint tidy vet test cover-report
 
 build: fmtcheck
 	@$(GO) install
@@ -83,6 +83,10 @@ tools:
 	@echo "=== $(PKG_NAME) === [ tools            ]: installing required tooling..."
 	@GO111MODULE=on $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint
 	@GO111MODULE=on go install github.com/bflad/tfproviderlint/cmd/tfproviderlint
+
+tidy:
+	@echo "=== $(PKG_NAME) === [ tidy             ]: tidying modules..."
+	@$(GO) mod tidy
 
 fmtcheck:
 	@echo "=== $(PKG_NAME) === [ fmtcheck         ]: Checking that code complies with gofmt requirements..."

--- a/newrelic/helpers_test.go
+++ b/newrelic/helpers_test.go
@@ -45,6 +45,7 @@ func deletePolicy(name string) func() {
 }
 
 // A custom check function to log the internal state during a test run.
+// nolint:deadcode,unused
 func logState(t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		t.Logf("State: %s\n", s)

--- a/newrelic/structures_newrelic_dashboard.go
+++ b/newrelic/structures_newrelic_dashboard.go
@@ -100,6 +100,8 @@ func expandWidget(cfg map[string]interface{}) (*newrelic.DashboardWidget, error)
 	return widget, nil
 }
 
+// TODO: Reduce the cyclomatic complexity of this func
+// nolint:gocyclo
 func validateWidgetData(cfg map[string]interface{}) error {
 	visualization := cfg["visualization"].(string)
 
@@ -316,8 +318,10 @@ func flattenDashboard(dashboard *newrelic.Dashboard, d *schema.ResourceData) err
 	return nil
 }
 
+// TODO: Reduce the cyclomatic complexity of this func
+// nolint:gocyclo
 func flattenWidgets(in *[]newrelic.DashboardWidget) []map[string]interface{} {
-	var out = make([]map[string]interface{}, len(*in), len(*in))
+	var out = make([]map[string]interface{}, len(*in))
 	for i, w := range *in {
 		m := make(map[string]interface{})
 		m["widget_id"] = w.ID
@@ -400,7 +404,7 @@ func flattenWidgets(in *[]newrelic.DashboardWidget) []map[string]interface{} {
 }
 
 func flattenWidgetDataCompareWith(in []newrelic.DashboardWidgetDataCompareWith) []map[string]interface{} {
-	var out = make([]map[string]interface{}, len(in), len(in))
+	var out = make([]map[string]interface{}, len(in))
 	for i, v := range in {
 		m := make(map[string]interface{})
 
@@ -423,7 +427,7 @@ func flattenWidgetDataCompareWithPresentation(in *newrelic.DashboardWidgetDataCo
 }
 
 func flattenWidgetDataMetrics(in []newrelic.DashboardWidgetDataMetric) []map[string]interface{} {
-	var out = make([]map[string]interface{}, len(in), len(in))
+	var out = make([]map[string]interface{}, len(in))
 	for i, v := range in {
 		m := make(map[string]interface{})
 


### PR DESCRIPTION
This PR fixes the linter errors when building via `make`, and also introduces a run of `go mod tidy` after the linters run to avoid altering `go.mod` and `go.sum`.