### PR TITLE
fix linting issues and enable linting in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,10 @@ go:
   - tip
 
 env:
-  - GOFLAGS=-mod=vendor GO111MODULE=on
+  GO111MODULE: 'on'
 
 script:
-- make test
-- make vet
+- make
 - make website-test
 
 matrix:

--- a/newrelic/resource_newrelic_alert_condition_test.go
+++ b/newrelic/resource_newrelic_alert_condition_test.go
@@ -139,7 +139,8 @@ func TestAccNewRelicAlertCondition(t *testing.T) {
 func TestAccNewRelicAlertCondition_nameGreaterThan64Char(t *testing.T) {
 	expectedErrorMsg, _ := regexp.Compile(`expected length of name to be in the range \(1 \- 64\)`)
 	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccCheckNewRelicAlertConditionConfig("really-long-name-longer-than-sixty-four-characters-so-it-causes-an-error"),
@@ -153,8 +154,9 @@ func TestAccNewRelicAlertCondition_MissingPolicy(t *testing.T) {
 	rName := acctest.RandString(5)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckNewRelicAlertConditionConfig(rName),
@@ -229,8 +231,9 @@ func TestErrorThrownUponConditionNameGreaterThan64Char(t *testing.T) {
 	expectedErrorMsg, _ := regexp.Compile(`expected length of name to be in the range \(1 \- 64\)`)
 	rName := acctest.RandString(5)
 	resource.Test(t, resource.TestCase{
-		IsUnitTest: true,
-		Providers:  testAccProviders,
+		IsUnitTest:   true,
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testErrorThrownUponConditionNameGreaterThan64Char(rName),
@@ -366,8 +369,9 @@ resource "newrelic_alert_condition" "foo" {
 func TestErrorThrownUponConditionNameLessThan1Char(t *testing.T) {
 	expectedErrorMsg, _ := regexp.Compile(`expected length of name to be in the range \(1 \- 64\)`)
 	resource.Test(t, resource.TestCase{
-		IsUnitTest: true,
-		Providers:  testAccProviders,
+		IsUnitTest:   true,
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testErrorThrownUponConditionNameLessThan1Char(),
@@ -408,8 +412,9 @@ resource "newrelic_alert_condition" "foo" {
 func TestErrorThrownUponConditionTermDurationGreaterThan120(t *testing.T) {
 	expectedErrorMsg, _ := regexp.Compile(`expected term.0.duration to be in the range \(5 - 120\)`)
 	resource.Test(t, resource.TestCase{
-		IsUnitTest: true,
-		Providers:  testAccProviders,
+		IsUnitTest:   true,
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testErrorThrownUponConditionTermDurationGreaterThan120(),
@@ -450,8 +455,9 @@ resource "newrelic_alert_condition" "foo" {
 func TestErrorThrownUponConditionTermDurationLessThan5(t *testing.T) {
 	expectedErrorMsg, _ := regexp.Compile(`expected term.0.duration to be in the range \(5 - 120\)`)
 	resource.Test(t, resource.TestCase{
-		IsUnitTest: true,
-		Providers:  testAccProviders,
+		IsUnitTest:   true,
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testErrorThrownUponConditionTermDurationLessThan5(),

--- a/newrelic/resource_newrelic_alert_policy_test.go
+++ b/newrelic/resource_newrelic_alert_policy_test.go
@@ -90,8 +90,9 @@ func TestAccNewRelicAlertPolicy_ErrorThrownWhenNameEmpty(t *testing.T) {
 	expectedErrorMsg, _ := regexp.Compile(`name must not be empty`)
 
 	resource.ParallelTest(t, resource.TestCase{
-		IsUnitTest: true,
-		Providers:  testAccProviders,
+		IsUnitTest:   true,
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAlertPolicyConfigNameEmpty(),

--- a/newrelic/resource_newrelic_infra_alert_condition_test.go
+++ b/newrelic/resource_newrelic_infra_alert_condition_test.go
@@ -155,8 +155,9 @@ func TestAccNewRelicInfraAlertCondition_MissingPolicy(t *testing.T) {
 	rName := acctest.RandString(5)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicInfraAlertConditionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckNewRelicInfraAlertConditionConfig(rName),

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -163,8 +163,9 @@ func TestAccNewRelicNrqlAlertCondition_MissingPolicy(t *testing.T) {
 	rName := acctest.RandString(5)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckNewRelicNrqlAlertConditionConfig(rName),

--- a/newrelic/resource_newrelic_synthetics_alert_condition_test.go
+++ b/newrelic/resource_newrelic_synthetics_alert_condition_test.go
@@ -48,8 +48,9 @@ func TestAccNewRelicSyntheticsAlertCondition_MissingPolicy(t *testing.T) {
 	rName := acctest.RandString(5)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicSyntheticsAlertConditionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckNewRelicSyntheticsAlertConditionConfig(rName),


### PR DESCRIPTION
This PR fixes the linting errors generated by `tfproviderlint` and enables a full run of `make` in Travis. 