### PR TITLE
feat: ability to import newrelic_alert_channel data source, update acceptance tests

### DIFF
--- a/newrelic/data_source_newrelic_alert_channel.go
+++ b/newrelic/data_source_newrelic_alert_channel.go
@@ -60,6 +60,7 @@ func dataSourceNewRelicAlertChannelRead(d *schema.ResourceData, meta interface{}
 	d.Set("name", channel.Name)
 	d.Set("type", channel.Type)
 	d.Set("policy_ids", channel.Links.PolicyIDs)
+	d.Set("configuration", channel.Configuration)
 
 	return nil
 }

--- a/newrelic/data_source_newrelic_alert_channel_test.go
+++ b/newrelic/data_source_newrelic_alert_channel_test.go
@@ -11,36 +11,30 @@ import (
 )
 
 func TestAccNewRelicAlertChannelDataSource_Basic(t *testing.T) {
+	resourceName := "newrelic_alert_channel.foo"
 	rName := acctest.RandString(5)
-	resource.Test(t, resource.TestCase{
+
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
+			// Test: Create
 			{
 				Config: testAccNewRelicAlertChannelDataSourceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNewRelicAlertChannel("data.newrelic_alert_channel.channel"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-test-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "type", "email"),
 				),
+			},
+			// Test: Import
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
-}
-
-func testAccNewRelicAlertChannel(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		r := s.RootModule().Resources[n]
-		a := r.Primary.Attributes
-
-		if a["id"] == "" {
-			return fmt.Errorf("expected to get an alert channel from New Relic")
-		}
-
-		if strings.Contains(strings.ToLower(testAccExpectedAlertChannelName), strings.ToLower(a["name"])) {
-			return fmt.Errorf("expected the alert channel name to be: %s, but got: %s", testAccExpectedAlertChannelName, a["name"])
-		}
-
-		return nil
-	}
 }
 
 func testAccNewRelicAlertChannelDataSourceConfig(rName string) string {
@@ -59,4 +53,21 @@ data "newrelic_alert_channel" "channel" {
 	name = "${newrelic_alert_channel.foo.name}"
 }
 `, rName)
+}
+
+func testAccNewRelicAlertChannel(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		if a["id"] == "" {
+			return fmt.Errorf("expected to get an alert channel from New Relic")
+		}
+
+		if strings.Contains(strings.ToLower(testAccExpectedAlertChannelName), strings.ToLower(a["name"])) {
+			return fmt.Errorf("expected the alert channel name to be: %s, but got: %s", testAccExpectedAlertChannelName, a["name"])
+		}
+
+		return nil
+	}
 }

--- a/newrelic/resource_newrelic_alert_channel.go
+++ b/newrelic/resource_newrelic_alert_channel.go
@@ -11,6 +11,7 @@ import (
 )
 
 var alertChannelTypes = map[string][]string{
+	// Campfire no longer supported by New Relic (remove this option from here and docs eventually)
 	"campfire": {
 		"room",
 		"subdomain",
@@ -20,6 +21,7 @@ var alertChannelTypes = map[string][]string{
 		"include_json_attachment",
 		"recipients",
 	},
+	// HipChat no longer supported by New Relic (remove this option from here and docs eventually)
 	"hipchat": {
 		"auth_token",
 		"base_url",

--- a/newrelic/resource_newrelic_alert_channel_test.go
+++ b/newrelic/resource_newrelic_alert_channel_test.go
@@ -11,56 +11,37 @@ import (
 )
 
 func TestAccNewRelicAlertChannel_Basic(t *testing.T) {
-	rName := acctest.RandString(5)
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNewRelicAlertChannelDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckNewRelicAlertChannelConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicAlertChannelExists("newrelic_alert_channel.foo"),
-					resource.TestCheckResourceAttr(
-						"newrelic_alert_channel.foo", "name", fmt.Sprintf("tf-test-%s", rName)),
-					resource.TestCheckResourceAttr(
-						"newrelic_alert_channel.foo", "type", "email"),
-					resource.TestCheckResourceAttr(
-						"newrelic_alert_channel.foo", "configuration.recipients", "terraform-acctest+foo@hashicorp.com"),
-					resource.TestCheckResourceAttr(
-						"newrelic_alert_channel.foo", "configuration.include_json_attachment", "1"),
-				),
-			},
-			{
-				Config: testAccCheckNewRelicAlertChannelConfigUpdated(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicAlertChannelExists("newrelic_alert_channel.foo"),
-					resource.TestCheckResourceAttr(
-						"newrelic_alert_channel.foo", "name", fmt.Sprintf("tf-test-updated-%s", rName)),
-					resource.TestCheckResourceAttr(
-						"newrelic_alert_channel.foo", "type", "email"),
-					resource.TestCheckResourceAttr(
-						"newrelic_alert_channel.foo", "configuration.recipients", "terraform-acctest+bar@hashicorp.com"),
-					resource.TestCheckResourceAttr(
-						"newrelic_alert_channel.foo", "configuration.include_json_attachment", "0"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccNewRelicAlertChannel(t *testing.T) {
 	resourceName := "newrelic_alert_channel.foo"
 	rName := acctest.RandString(5)
-	resource.Test(t, resource.TestCase{
+
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicAlertChannelDestroy,
 		Steps: []resource.TestStep{
+			// Test: Create
 			{
-				Config: testAccCheckNewRelicAlertChannelConfig(rName),
+				Config: testAccNewRelicAlertChannelConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAlertChannelExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-test-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "type", "email"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.recipients", "terraform-acctest+foo@hashicorp.com"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.include_json_attachment", "1"),
+				),
 			},
-
+			// Test: Update
+			{
+				Config: testAccNewRelicAlertChannelConfigUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAlertChannelExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-test-updated-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "type", "email"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.recipients", "terraform-acctest+bar@hashicorp.com"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.include_json_attachment", "0"),
+				),
+			},
+			// Test: Import
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -68,6 +49,225 @@ func TestAccNewRelicAlertChannel(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccNewRelicAlertChannel_Slack(t *testing.T) {
+	resourceName := "newrelic_alert_channel.foo"
+	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNewRelicAlertChannelConfigByType(rName, "slack", `{
+					url = "https://example.slack.com"
+					channel = "example-channel"
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAlertChannelExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-test-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "type", "slack"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.url", "https://example.slack.com"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.channel", "example-channel"),
+				),
+				// This notification channel resource requires being destroyed and recreated on every `apply`.
+				// This is due to how the New Relic API has to handle this scenario, hence we need to set this to `true`.
+				ExpectNonEmptyPlan: true,
+			},
+			// Test: Import
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccNewRelicAlertChannel_PagerDuty(t *testing.T) {
+	resourceName := "newrelic_alert_channel.foo"
+	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNewRelicAlertChannelConfigByType(rName, "pagerduty", `{
+					service_key = "abc123"
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAlertChannelExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-test-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "type", "pagerduty"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.service_key", "abc123"),
+				),
+				// This notification channel resource requires being destroyed and recreated on every `apply`.
+				// This is due to how the New Relic API has to handle this scenario, hence we need to set this to `true`.
+				ExpectNonEmptyPlan: true,
+			},
+			// Test: Import
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccNewRelicAlertChannel_OpsGenie(t *testing.T) {
+	resourceName := "newrelic_alert_channel.foo"
+	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNewRelicAlertChannelConfigByType(rName, "opsgenie", `{
+					api_key = "abc123"
+					teams = "example-team"
+					tags = "tag1"
+					recipients = "example@somedomain.com"
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAlertChannelExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-test-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "type", "opsgenie"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.api_key", "abc123"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.teams", "example-team"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.tags", "tag1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.recipients", "example@somedomain.com"),
+				),
+				// This notification channel resource requires being destroyed and recreated on every `apply`.
+				// This is due to how the New Relic API has to handle this scenario, hence we need to set this to `true`.
+				ExpectNonEmptyPlan: true,
+			},
+			// Test: Import
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccNewRelicAlertChannel_VictorOps(t *testing.T) {
+	resourceName := "newrelic_alert_channel.foo"
+	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNewRelicAlertChannelConfigByType(rName, "victorops", `{
+					key = "abc123"
+					route_key = "/example-route"
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAlertChannelExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-test-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "type", "victorops"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.key", "abc123"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.route_key", "/example-route"),
+				),
+				// This notification channel resource requires being destroyed and recreated on every `apply`.
+				// This is due to how the New Relic API has to handle this scenario, hence we need to set this to `true`.
+				ExpectNonEmptyPlan: true,
+			},
+			// Test: Import
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccNewRelicAlertChannel_NoDiffOnReapply(t *testing.T) {
+	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNewRelicAlertChannelConfig(rName),
+			},
+			{
+				Config:             testAccNewRelicAlertChannelConfig(rName),
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestAccNewRelicAlertChannel_ResourceNotFound(t *testing.T) {
+	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNewRelicAlertChannelConfig(rName),
+			},
+			{
+				PreConfig: testAccDeleteAlertChannel(rName),
+				Config:    testAccNewRelicAlertChannelConfig(rName),
+			},
+		},
+	})
+}
+
+func testAccNewRelicAlertChannelConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "newrelic_alert_channel" "foo" {
+  name = "tf-test-%s"
+	type = "email"
+
+	configuration = {
+		recipients = "terraform-acctest+foo@hashicorp.com"
+		include_json_attachment = "1"
+	}
+}
+`, rName)
+}
+
+func testAccNewRelicAlertChannelConfigUpdated(rName string) string {
+	return fmt.Sprintf(`
+resource "newrelic_alert_channel" "foo" {
+  name = "tf-test-updated-%s"
+	type = "email"
+
+	configuration = {
+		recipients = "terraform-acctest+bar@hashicorp.com"
+		include_json_attachment = "0"
+	}
+}
+`, rName)
+}
+
+func testAccNewRelicAlertChannelConfigByType(rName string, channelType string, configuration string) string {
+	return fmt.Sprintf(`
+		resource "newrelic_alert_channel" "foo" {
+			name = "tf-test-%s"
+			type = "%s"
+
+			configuration = %s
+		}
+	`, rName, channelType, configuration)
 }
 
 func testAccCheckNewRelicAlertChannelDestroy(s *terraform.State) error {
@@ -122,30 +322,16 @@ func testAccCheckNewRelicAlertChannelExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckNewRelicAlertChannelConfig(rName string) string {
-	return fmt.Sprintf(`
-resource "newrelic_alert_channel" "foo" {
-  name = "tf-test-%s"
-	type = "email"
-	
-	configuration = {
-		recipients = "terraform-acctest+foo@hashicorp.com"
-		include_json_attachment = "1"
-	}
-}
-`, rName)
-}
+func testAccDeleteAlertChannel(name string) func() {
+	return func() {
+		client := testAccProvider.Meta().(*ProviderConfig).Client
+		alertChannels, _ := client.ListAlertChannels()
 
-func testAccCheckNewRelicAlertChannelConfigUpdated(rName string) string {
-	return fmt.Sprintf(`
-resource "newrelic_alert_channel" "foo" {
-  name = "tf-test-updated-%s"
-	type = "email"
-	
-	configuration = {
-		recipients = "terraform-acctest+bar@hashicorp.com"
-		include_json_attachment = "0"
+		for _, d := range alertChannels {
+			if d.Name == name {
+				_ = client.DeleteAlertChannel(d.ID)
+				break
+			}
+		}
 	}
-}
-`, rName)
 }

--- a/website/docs/d/alert_channel.html.markdown
+++ b/website/docs/d/alert_channel.html.markdown
@@ -8,19 +8,22 @@ description: |-
 
 # newrelic\_alert\_channel
 
-Use this data source to get information about an specific alert channel in New Relic which already exists (e.g newrelic user).
+Use this data source to get information about a specific alert channel in New Relic that already exists (e.g newrelic user). More information on Terraform's data sources can be found [here](https://www.terraform.io/docs/configuration/data-sources.html).
 
 ## Example Usage
 
 ```hcl
+# Data source
 data "newrelic_alert_channel" "foo" {
   name = "foo@example.com"
 }
 
+# Resource
 resource "newrelic_alert_policy" "foo" {
   name = "foo"
 }
 
+# Using the data source and resource together
 resource "newrelic_alert_policy_channel" "foo" {
   policy_id  = "${newrelic_alert_policy.foo.id}"
   channel_id = "${data.newrelic_alert_channel.foo.id}"
@@ -35,5 +38,5 @@ The following arguments are supported:
 
 ## Attributes Reference
 * `id` - The ID of the alert channel.
-* `type` - Alert channel type, either: `campfire`, `email`, `hipchat`, `opsgenie`, `pagerduty`, `slack`, `victorops`, or `webhook`..
+* `type` - Alert channel type, either: `email`, `opsgenie`, `pagerduty`, `slack`, `victorops`, or `webhook`.
 * `policy_ids` - A list of policy IDs associated with the alert channel.

--- a/website/docs/r/alert_channel.html.markdown
+++ b/website/docs/r/alert_channel.html.markdown
@@ -10,6 +10,7 @@ description: |-
 
 ## Example Usage
 
+##### Email
 ```hcl
 resource "newrelic_alert_channel" "foo" {
   name = "foo"
@@ -21,14 +22,15 @@ resource "newrelic_alert_channel" "foo" {
   }
 }
 ```
+See additional [examples](#additional-examples).
 
 ## Argument Reference
 
 The following arguments are supported:
 
   * `name` - (Required) The name of the channel.
-  * `type` - (Required) The type of channel.  One of: `campfire`, `email`, `hipchat`, `opsgenie`, `pagerduty`, `slack`, `victorops`, or `webhook`.
-  * `configuration` - (Required) A map of key / value pairs with channel type specific values.
+  * `type` - (Required) The type of channel.  One of: `email`, `slack`, `opsgenie`, `pagerduty`, `victorops`, or `webhook`.
+  * `configuration` - (Required) A map of key / value pairs with channel type specific values. See [channel configurations](#channel-configurations) for specific configurations for the different channel types.
 
 ## Attributes Reference
 
@@ -36,10 +38,86 @@ The following attributes are exported:
 
   * `id` - The ID of the channel.
 
+## Channel Configurations
+
+Each supported channel supports a particular set of configuration arguments.
+
+  * `email`
+    * `recipients` - (Required) Comma delimited list of email addresses.
+    * `include_json_attachment` - (Optional) `0` or `1`. Flag for whether or not to attach a JSON document containing information about the associated alert to the email that is sent to recipients. Default: `0`
+  * `slack`
+    * `url` - (Required) Your organization's Slack URL.
+    * `channel` - (Required) The Slack channel for which to send notifications.
+  * `opsgenie`
+    * `api_key` - (Required) Your OpsGenie API key.
+    * `teams` - (Optional) Comma delimited list of teams.
+    * `tags` - (Optional) Comma delimited list of tags.
+    * `recipients` - (Optional) Comma delimited list of email addresses.
+  * `pagerduty`
+    * `service_key` - (Required) Your PagerDuty service key.
+  * `victorops`
+    * `key` - (Required) Your VictorOps key.
+    * `route_key` - (Required) The route for which to send notifications.
+
+## Additional Examples
+
+##### Slack
+```hcl
+resource "newrelic_alert_channel" "foo" {
+  name = "slack-example"
+  type = "slack"
+
+  configuration = {
+    url     = "https://<YourOrganization>.slack.com"
+    channel = "example-alerts-channel"
+  }
+}
+```
+
+##### OpsGenie
+```hcl
+resource "newrelic_alert_channel" "foo" {
+  name = "opsgenie-example"
+  type = "opsgenie"
+
+  configuration = {
+    api_key    = "abc123"
+    teams      = "team1, team2"
+    tags       = "tag1, tag2"
+    recipients = "user1@domain.com, user2@domain.com"
+  }
+}
+```
+
+##### PagerDuty
+```hcl
+resource "newrelic_alert_channel" "foo" {
+  name = "pagerduty-example"
+  type = "pagerduty"
+
+  configuration = {
+    service_key = "abc123"
+  }
+}
+```
+
+##### VictorOps
+```hcl
+resource "newrelic_alert_channel" "foo" {
+  name = "victorops-example"
+  type = "victorops"
+
+  configuration = {
+    key       = "abc123"
+    route_key = "/example"
+  }
+}
+```
+
 ## Import
 
 Alert channels can be imported using the `id`, e.g.
 
-```
-$ terraform import newrelic_alert_channel.main 12345
+```bash
+$ terraform import newrelic_alert_channel.main <id>
 ```


### PR DESCRIPTION
Resolves: #215 

IMPROVEMENTS:
* Add ability to import `newrelic_alert_channel` **data** source
* Minor updates to `newrelic_alert_channel` **data** source acceptance tests
* Increased test coverage for the different channels in `newrelic_alert_channel` **resource**