### PR TITLE
Backfill alert condition acceptance tests

### DIFF
--- a/newrelic/helpers_test.go
+++ b/newrelic/helpers_test.go
@@ -30,7 +30,7 @@ func TestSerializeIDs_Basic(t *testing.T) {
 	}
 }
 
-func deletePolicy(name string) func() {
+func testAccDeleteNewRelicAlertPolicy(name string) func() {
 	return func() {
 		client := testAccProvider.Meta().(*ProviderConfig).Client
 		policies, _ := client.ListAlertPolicies()

--- a/newrelic/provider_test.go
+++ b/newrelic/provider_test.go
@@ -16,6 +16,7 @@ var (
 	testAccExpectedAlertChannelName string
 	testAccExpectedApplicationName  string
 	testAccExpectedAlertPolicyName  string
+	testAccAPIKey                   string
 	testAccProviders                map[string]terraform.ResourceProvider
 	testAccProvider                 *schema.Provider
 )
@@ -27,6 +28,11 @@ func init() {
 	testAccProvider = Provider().(*schema.Provider)
 	testAccProviders = map[string]terraform.ResourceProvider{
 		"newrelic": testAccProvider,
+	}
+
+	testAccAPIKey = os.Getenv("NEWRELIC_API_KEY")
+	if v := os.Getenv("NEWRELIC_API_KEY"); v == "" {
+		testAccAPIKey = "foo"
 	}
 }
 

--- a/newrelic/resource_newrelic_alert_condition_test.go
+++ b/newrelic/resource_newrelic_alert_condition_test.go
@@ -20,7 +20,7 @@ func TestAccNewRelicAlertCondition_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
 		Steps: []resource.TestStep{
-			// Create
+			// Test: Create
 			{
 				Config: testAccCheckNewRelicAlertConditionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
@@ -53,12 +53,12 @@ func TestAccNewRelicAlertCondition_Basic(t *testing.T) {
 						"newrelic_alert_condition.foo", "term.1025554152.time_function", "all"),
 				),
 			},
-			// Check no diff on re-apply
+			// Test: Check no diff on re-apply
 			{
 				Config:             testAccCheckNewRelicAlertConditionConfig(rName),
 				ExpectNonEmptyPlan: false,
 			},
-			// Update
+			// Test: Update
 			{
 				Config: testAccCheckNewRelicAlertConditionConfigUpdated(rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
@@ -91,7 +91,7 @@ func TestAccNewRelicAlertCondition_Basic(t *testing.T) {
 						"newrelic_alert_condition.foo", "term.3409672004.time_function", "any"),
 				),
 			},
-			// Import
+			// Test: Import
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -142,8 +142,9 @@ func TestAccNewRelicAlertCondition_ShortTermDuration(t *testing.T) {
 	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
 	expectedErrorMsg, _ := regexp.Compile(`expected term.0.duration to be in the range \(5 - 120\)`)
 	resource.ParallelTest(t, resource.TestCase{
-		IsUnitTest: true,
-		Providers:  testAccProviders,
+		IsUnitTest:   true,
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccNewRelicAlertConditionConfigDuration(rName, 4),
@@ -157,8 +158,9 @@ func TestAccNewRelicAlertCondition_LongTermDuration(t *testing.T) {
 	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
 	expectedErrorMsg, _ := regexp.Compile(`expected term.0.duration to be in the range \(5 - 120\)`)
 	resource.ParallelTest(t, resource.TestCase{
-		IsUnitTest: true,
-		Providers:  testAccProviders,
+		IsUnitTest:   true,
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccNewRelicAlertConditionConfigDuration(rName, 121),
@@ -171,7 +173,9 @@ func TestAccNewRelicAlertCondition_LongTermDuration(t *testing.T) {
 func TestAccNewRelicAlertCondition_LongName(t *testing.T) {
 	expectedErrorMsg, _ := regexp.Compile(`expected length of name to be in the range \(1 \- 64\)`)
 	resource.ParallelTest(t, resource.TestCase{
-		Providers: testAccProviders,
+		IsUnitTest:   true,
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccCheckNewRelicAlertConditionConfig("really-long-name-longer-than-sixty-four-characters-so-it-causes-an-error"),
@@ -184,8 +188,9 @@ func TestAccNewRelicAlertCondition_LongName(t *testing.T) {
 func TestAccNewRelicAlertCondition_EmptyName(t *testing.T) {
 	expectedErrorMsg, _ := regexp.Compile(`name must not be empty`)
 	resource.ParallelTest(t, resource.TestCase{
-		IsUnitTest: true,
-		Providers:  testAccProviders,
+		IsUnitTest:   true,
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccCheckNewRelicAlertConditionConfig(""),
@@ -257,11 +262,9 @@ func testAccCheckNewRelicAlertConditionConfig(rName string) string {
 data "newrelic_application" "app" {
 	name = "%[2]s"
 }
-
 resource "newrelic_alert_policy" "foo" {
   name = "%[1]s"
 }
-
 resource "newrelic_alert_condition" "foo" {
   policy_id = "${newrelic_alert_policy.foo.id}"
 
@@ -289,11 +292,9 @@ func testAccCheckNewRelicAlertConditionConfigUpdated(name string) string {
 data "newrelic_application" "app" {
 	name = "%[2]s"
 }
-
 resource "newrelic_alert_policy" "foo" {
   name = "%[1]s"
 }
-
 resource "newrelic_alert_condition" "foo" {
   policy_id = "${newrelic_alert_policy.foo.id}"
 
@@ -321,11 +322,9 @@ func testAccCheckNewRelicAlertConditionConfigThreshold(name string, threshold in
 data "newrelic_application" "app" {
 	name = "%[3]s"
 }
-
 resource "newrelic_alert_policy" "foo" {
   name = "%[1]s"
 }
-
 resource "newrelic_alert_condition" "foo" {
   policy_id = "${newrelic_alert_policy.foo.id}"
 
@@ -353,7 +352,6 @@ func testAccNewRelicAlertConditionConfigDuration(name string, duration int) stri
 provider "newrelic" {
   api_key = "foo"
 }
-
 resource "newrelic_alert_policy" "foo" {
   name = "%[1]s"
 }

--- a/newrelic/resource_newrelic_alert_condition_test.go
+++ b/newrelic/resource_newrelic_alert_condition_test.go
@@ -259,32 +259,35 @@ func testAccCheckNewRelicAlertConditionExists(n string) resource.TestCheckFunc {
 
 func testAccCheckNewRelicAlertConditionConfig(rName string) string {
 	return fmt.Sprintf(`
+provider "newrelic" {
+	api_key = "%[3]s"
+}
 data "newrelic_application" "app" {
 	name = "%[2]s"
 }
 resource "newrelic_alert_policy" "foo" {
-  name = "%[1]s"
+	name = "%[1]s"
 }
 resource "newrelic_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+	policy_id = "${newrelic_alert_policy.foo.id}"
 
-  name            = "%[1]s"
-  enabled         = true
-  type            = "apm_app_metric"
-  entities        = ["${data.newrelic_application.app.id}"]
-  metric          = "apdex"
-  runbook_url     = "https://foo.example.com"
-  condition_scope = "application"
+	name            = "%[1]s"
+	enabled         = true
+	type            = "apm_app_metric"
+	entities        = ["${data.newrelic_application.app.id}"]
+	metric          = "apdex"
+	runbook_url     = "https://foo.example.com"
+	condition_scope = "application"
 
-  term {
-    duration      = 5
-    operator      = "below"
-    priority      = "critical"
-    threshold     = "0.75"
-    time_function = "all"
-  }
+	term {
+		duration      = 5
+		operator      = "below"
+		priority      = "critical"
+		threshold     = "0.75"
+		time_function = "all"
+	}
 }
-`, rName, testAccExpectedApplicationName)
+`, rName, testAccExpectedApplicationName, testAccAPIKey)
 }
 
 func testAccCheckNewRelicAlertConditionConfigUpdated(name string) string {
@@ -293,26 +296,26 @@ data "newrelic_application" "app" {
 	name = "%[2]s"
 }
 resource "newrelic_alert_policy" "foo" {
-  name = "%[1]s"
+	name = "%[1]s"
 }
 resource "newrelic_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+	policy_id = "${newrelic_alert_policy.foo.id}"
 
-  name            = "%[1]s"
-  enabled         = false
-  type            = "apm_app_metric"
-  entities        = ["${data.newrelic_application.app.id}"]
-  metric          = "error_percentage"
-  runbook_url     = "https://bar.example.com"
-  condition_scope = "application"
+	name            = "%[1]s"
+	enabled         = false
+	type            = "apm_app_metric"
+	entities        = ["${data.newrelic_application.app.id}"]
+	metric          = "error_percentage"
+	runbook_url     = "https://bar.example.com"
+	condition_scope = "application"
 
-  term {
-    duration      = 10 
-    operator      = "above"
-    priority      = "critical"
-    threshold     = "1.00"
-    time_function = "any"
-  }
+	term {
+		duration      = 10
+		operator      = "above"
+		priority      = "critical"
+		threshold     = "1.00"
+		time_function = "any"
+	}
 }
 `, name, testAccExpectedApplicationName)
 }
@@ -323,26 +326,26 @@ data "newrelic_application" "app" {
 	name = "%[3]s"
 }
 resource "newrelic_alert_policy" "foo" {
-  name = "%[1]s"
+	name = "%[1]s"
 }
 resource "newrelic_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+	policy_id = "${newrelic_alert_policy.foo.id}"
 
-  name            = "%[1]s"
-  enabled         = false
-  type            = "apm_app_metric"
-  entities        = ["${data.newrelic_application.app.id}"]
-  metric          = "apdex"
-  runbook_url     = "https://foo.example.com"
-  condition_scope = "application"
+	name            = "%[1]s"
+	enabled         = false
+	type            = "apm_app_metric"
+	entities        = ["${data.newrelic_application.app.id}"]
+	metric          = "apdex"
+	runbook_url     = "https://foo.example.com"
+	condition_scope = "application"
 
-  term {
-    duration      = 5
-    operator      = "below"
-    priority      = "critical"
-    threshold     = "%d"
-    time_function = "all"
-  }
+	term {
+		duration      = 5
+		operator      = "below"
+		priority      = "critical"
+		threshold     = "%d"
+		time_function = "all"
+	}
 }
 `, name, threshold, testAccExpectedApplicationName)
 }
@@ -350,26 +353,26 @@ resource "newrelic_alert_condition" "foo" {
 func testAccNewRelicAlertConditionConfigDuration(name string, duration int) string {
 	return fmt.Sprintf(`
 provider "newrelic" {
-  api_key = "foo"
+	api_key = "foo"
 }
 resource "newrelic_alert_policy" "foo" {
-  name = "%[1]s"
+	name = "%[1]s"
 }
 resource "newrelic_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
-  name            = "test-term-duration"
-  type            = "apm_app_metric"
-  entities        = ["12345"]
-  metric          = "apdex"
-  runbook_url     = "https://foo.example.com"
-  condition_scope = "application"
-  term {
-    duration      = %[2]d
-    operator      = "below"
-    priority      = "critical"
-    threshold     = "0.75"
-    time_function = "all"
-  }
+	policy_id = "${newrelic_alert_policy.foo.id}"
+	name            = "test-term-duration"
+	type            = "apm_app_metric"
+	entities        = ["12345"]
+	metric          = "apdex"
+	runbook_url     = "https://foo.example.com"
+	condition_scope = "application"
+	term {
+		duration      = %[2]d
+		operator      = "below"
+		priority      = "critical"
+		threshold     = "0.75"
+		time_function = "all"
+	}
 }
 `, name, duration)
 }

--- a/newrelic/resource_newrelic_alert_condition_test.go
+++ b/newrelic/resource_newrelic_alert_condition_test.go
@@ -170,6 +170,63 @@ func TestAccNewRelicAlertCondition_MissingPolicy(t *testing.T) {
 	})
 }
 
+func TestErrorThrownUponConditionTermDurationLessThan5(t *testing.T) {
+	expectedErrorMsg, _ := regexp.Compile(`expected term.0.duration to be in the range \(5 - 120\)`)
+	resource.ParallelTest(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testErrorThrownUponConditionTermDurationLessThan5(),
+				ExpectError: expectedErrorMsg,
+			},
+		},
+	})
+}
+
+func TestErrorThrownUponConditionNameGreaterThan64Char(t *testing.T) {
+	expectedErrorMsg, _ := regexp.Compile(`expected length of name to be in the range \(1 \- 64\)`)
+	rName := acctest.RandString(5)
+	resource.ParallelTest(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testErrorThrownUponConditionNameGreaterThan64Char(rName),
+				ExpectError: expectedErrorMsg,
+			},
+		},
+	})
+}
+
+func TestErrorThrownUponConditionNameLessThan1Char(t *testing.T) {
+	expectedErrorMsg, _ := regexp.Compile(`expected length of name to be in the range \(1 \- 64\)`)
+	resource.ParallelTest(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testErrorThrownUponConditionNameLessThan1Char(),
+				ExpectError: expectedErrorMsg,
+			},
+		},
+	})
+}
+
+func TestErrorThrownUponConditionTermDurationGreaterThan120(t *testing.T) {
+	expectedErrorMsg, _ := regexp.Compile(`expected term.0.duration to be in the range \(5 - 120\)`)
+	resource.ParallelTest(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testErrorThrownUponConditionTermDurationGreaterThan120(),
+				ExpectError: expectedErrorMsg,
+			},
+		},
+	})
+}
+
 func testAccCheckNewRelicAlertConditionDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*ProviderConfig).Client
 	for _, r := range s.RootModule().Resources {
@@ -225,22 +282,6 @@ func testAccCheckNewRelicAlertConditionExists(n string) resource.TestCheckFunc {
 
 		return nil
 	}
-}
-
-func TestErrorThrownUponConditionNameGreaterThan64Char(t *testing.T) {
-	expectedErrorMsg, _ := regexp.Compile(`expected length of name to be in the range \(1 \- 64\)`)
-	rName := acctest.RandString(5)
-	resource.ParallelTest(t, resource.TestCase{
-		IsUnitTest:   true,
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testErrorThrownUponConditionNameGreaterThan64Char(rName),
-				ExpectError: expectedErrorMsg,
-			},
-		},
-	})
 }
 
 func testAccCheckNewRelicAlertConditionConfig(rName string) string {
@@ -366,21 +407,6 @@ resource "newrelic_alert_condition" "foo" {
 `, resourceName, testAccExpectedApplicationName)
 }
 
-func TestErrorThrownUponConditionNameLessThan1Char(t *testing.T) {
-	expectedErrorMsg, _ := regexp.Compile(`expected length of name to be in the range \(1 \- 64\)`)
-	resource.ParallelTest(t, resource.TestCase{
-		IsUnitTest:   true,
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testErrorThrownUponConditionNameLessThan1Char(),
-				ExpectError: expectedErrorMsg,
-			},
-		},
-	})
-}
-
 func testErrorThrownUponConditionNameLessThan1Char() string {
 	return `
 provider "newrelic" {
@@ -407,21 +433,6 @@ resource "newrelic_alert_condition" "foo" {
   }
 }
 `
-}
-
-func TestErrorThrownUponConditionTermDurationGreaterThan120(t *testing.T) {
-	expectedErrorMsg, _ := regexp.Compile(`expected term.0.duration to be in the range \(5 - 120\)`)
-	resource.ParallelTest(t, resource.TestCase{
-		IsUnitTest:   true,
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testErrorThrownUponConditionTermDurationGreaterThan120(),
-				ExpectError: expectedErrorMsg,
-			},
-		},
-	})
 }
 
 func testErrorThrownUponConditionTermDurationGreaterThan120() string {
@@ -452,21 +463,6 @@ resource "newrelic_alert_condition" "foo" {
 `
 }
 
-func TestErrorThrownUponConditionTermDurationLessThan5(t *testing.T) {
-	expectedErrorMsg, _ := regexp.Compile(`expected term.0.duration to be in the range \(5 - 120\)`)
-	resource.ParallelTest(t, resource.TestCase{
-		IsUnitTest:   true,
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testErrorThrownUponConditionTermDurationLessThan5(),
-				ExpectError: expectedErrorMsg,
-			},
-		},
-	})
-}
-
 func testErrorThrownUponConditionTermDurationLessThan5() string {
 	return `
 provider "newrelic" {
@@ -494,5 +490,3 @@ resource "newrelic_alert_condition" "foo" {
 }
 `
 }
-
-// TODO: const testAccCheckNewRelicAlertConditionConfigMulti = `

--- a/newrelic/resource_newrelic_alert_condition_test.go
+++ b/newrelic/resource_newrelic_alert_condition_test.go
@@ -22,7 +22,7 @@ func TestAccNewRelicAlertCondition_Basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test: Create
 			{
-				Config: testAccCheckNewRelicAlertConditionConfig(rName),
+				Config: testAccNewRelicAlertConditionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicAlertConditionExists("newrelic_alert_condition.foo"),
 					resource.TestCheckResourceAttr(
@@ -55,12 +55,12 @@ func TestAccNewRelicAlertCondition_Basic(t *testing.T) {
 			},
 			// Test: Check no diff on re-apply
 			{
-				Config:             testAccCheckNewRelicAlertConditionConfig(rName),
+				Config:             testAccNewRelicAlertConditionConfig(rName),
 				ExpectNonEmptyPlan: false,
 			},
 			// Test: Update
 			{
-				Config: testAccCheckNewRelicAlertConditionConfigUpdated(rNameUpdated),
+				Config: testAccNewRelicAlertConditionConfigUpdated(rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicAlertConditionExists("newrelic_alert_condition.foo"),
 					resource.TestCheckResourceAttr(
@@ -109,7 +109,7 @@ func TestAccNewRelicAlertCondition_ZeroThreshold(t *testing.T) {
 		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckNewRelicAlertConditionConfigThreshold(rName, 0),
+				Config: testAccNewRelicAlertConditionConfigThreshold(rName, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicAlertConditionExists("newrelic_alert_condition.foo"),
 				),
@@ -127,11 +127,11 @@ func TestAccNewRelicAlertCondition_AlertPolicyNotFound(t *testing.T) {
 		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckNewRelicAlertConditionConfig(rName),
+				Config: testAccNewRelicAlertConditionConfig(rName),
 			},
 			{
 				PreConfig: testAccDeleteNewRelicAlertPolicy(rName),
-				Config:    testAccCheckNewRelicAlertConditionConfig(rName),
+				Config:    testAccNewRelicAlertConditionConfig(rName),
 				Check:     testAccCheckNewRelicAlertConditionExists("newrelic_alert_condition.foo"),
 			},
 		},
@@ -178,7 +178,7 @@ func TestAccNewRelicAlertCondition_LongName(t *testing.T) {
 		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCheckNewRelicAlertConditionConfig("really-long-name-longer-than-sixty-four-characters-so-it-causes-an-error"),
+				Config:      testAccNewRelicAlertConditionConfig("really-long-name-longer-than-sixty-four-characters-so-it-causes-an-error"),
 				ExpectError: expectedErrorMsg,
 			},
 		},
@@ -193,7 +193,7 @@ func TestAccNewRelicAlertCondition_EmptyName(t *testing.T) {
 		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCheckNewRelicAlertConditionConfig(""),
+				Config:      testAccNewRelicAlertConditionConfig(""),
 				ExpectError: expectedErrorMsg,
 			},
 		},
@@ -257,7 +257,7 @@ func testAccCheckNewRelicAlertConditionExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckNewRelicAlertConditionConfig(rName string) string {
+func testAccNewRelicAlertConditionConfig(rName string) string {
 	return fmt.Sprintf(`
 provider "newrelic" {
 	api_key = "%[3]s"
@@ -290,7 +290,7 @@ resource "newrelic_alert_condition" "foo" {
 `, rName, testAccExpectedApplicationName, testAccAPIKey)
 }
 
-func testAccCheckNewRelicAlertConditionConfigUpdated(name string) string {
+func testAccNewRelicAlertConditionConfigUpdated(name string) string {
 	return fmt.Sprintf(`
 data "newrelic_application" "app" {
 	name = "%[2]s"
@@ -320,7 +320,7 @@ resource "newrelic_alert_condition" "foo" {
 `, name, testAccExpectedApplicationName)
 }
 
-func testAccCheckNewRelicAlertConditionConfigThreshold(name string, threshold int) string {
+func testAccNewRelicAlertConditionConfigThreshold(name string, threshold int) string {
 	return fmt.Sprintf(`
 data "newrelic_application" "app" {
 	name = "%[3]s"

--- a/newrelic/resource_newrelic_alert_condition_test.go
+++ b/newrelic/resource_newrelic_alert_condition_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAccNewRelicAlertCondition_Basic(t *testing.T) {
 	rName := acctest.RandString(5)
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
@@ -77,7 +77,7 @@ func TestAccNewRelicAlertCondition_Basic(t *testing.T) {
 
 func TestAccNewRelicAlertCondition_ZeroThreshold(t *testing.T) {
 	rName := acctest.RandString(5)
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
@@ -118,7 +118,7 @@ func TestAccNewRelicAlertCondition(t *testing.T) {
 	resourceName := "newrelic_alert_condition.foo"
 	rName := acctest.RandString(5)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
@@ -138,7 +138,7 @@ func TestAccNewRelicAlertCondition(t *testing.T) {
 
 func TestAccNewRelicAlertCondition_nameGreaterThan64Char(t *testing.T) {
 	expectedErrorMsg, _ := regexp.Compile(`expected length of name to be in the range \(1 \- 64\)`)
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
 		Steps: []resource.TestStep{
@@ -153,7 +153,7 @@ func TestAccNewRelicAlertCondition_nameGreaterThan64Char(t *testing.T) {
 func TestAccNewRelicAlertCondition_MissingPolicy(t *testing.T) {
 	rName := acctest.RandString(5)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
@@ -230,7 +230,7 @@ func testAccCheckNewRelicAlertConditionExists(n string) resource.TestCheckFunc {
 func TestErrorThrownUponConditionNameGreaterThan64Char(t *testing.T) {
 	expectedErrorMsg, _ := regexp.Compile(`expected length of name to be in the range \(1 \- 64\)`)
 	rName := acctest.RandString(5)
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		IsUnitTest:   true,
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
@@ -368,7 +368,7 @@ resource "newrelic_alert_condition" "foo" {
 
 func TestErrorThrownUponConditionNameLessThan1Char(t *testing.T) {
 	expectedErrorMsg, _ := regexp.Compile(`expected length of name to be in the range \(1 \- 64\)`)
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		IsUnitTest:   true,
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
@@ -411,7 +411,7 @@ resource "newrelic_alert_condition" "foo" {
 
 func TestErrorThrownUponConditionTermDurationGreaterThan120(t *testing.T) {
 	expectedErrorMsg, _ := regexp.Compile(`expected term.0.duration to be in the range \(5 - 120\)`)
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		IsUnitTest:   true,
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
@@ -454,7 +454,7 @@ resource "newrelic_alert_condition" "foo" {
 
 func TestErrorThrownUponConditionTermDurationLessThan5(t *testing.T) {
 	expectedErrorMsg, _ := regexp.Compile(`expected term.0.duration to be in the range \(5 - 120\)`)
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		IsUnitTest:   true,
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,

--- a/newrelic/resource_newrelic_infra_alert_condition_test.go
+++ b/newrelic/resource_newrelic_infra_alert_condition_test.go
@@ -163,7 +163,7 @@ func TestAccNewRelicInfraAlertCondition_MissingPolicy(t *testing.T) {
 				Config: testAccCheckNewRelicInfraAlertConditionConfig(rName),
 			},
 			{
-				PreConfig: deletePolicy(fmt.Sprintf("tf-test-%s", rName)),
+				PreConfig: testAccDeleteNewRelicAlertPolicy(fmt.Sprintf("tf-test-%s", rName)),
 				Config:    testAccCheckNewRelicInfraAlertConditionConfig(rName),
 				Check:     testAccCheckNewRelicInfraAlertConditionExists("newrelic_infra_alert_condition.foo"),
 			},

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -171,7 +171,7 @@ func TestAccNewRelicNrqlAlertCondition_MissingPolicy(t *testing.T) {
 				Config: testAccCheckNewRelicNrqlAlertConditionConfig(rName),
 			},
 			{
-				PreConfig: deletePolicy(fmt.Sprintf("tf-test-%s", rName)),
+				PreConfig: testAccDeleteNewRelicAlertPolicy(fmt.Sprintf("tf-test-%s", rName)),
 				Config:    testAccCheckNewRelicNrqlAlertConditionConfig(rName),
 				Check:     testAccCheckNewRelicNrqlAlertConditionExists("newrelic_nrql_alert_condition.foo"),
 			},

--- a/newrelic/resource_newrelic_synthetics_alert_condition_test.go
+++ b/newrelic/resource_newrelic_synthetics_alert_condition_test.go
@@ -56,7 +56,7 @@ func TestAccNewRelicSyntheticsAlertCondition_MissingPolicy(t *testing.T) {
 				Config: testAccCheckNewRelicSyntheticsAlertConditionConfig(rName),
 			},
 			{
-				PreConfig: deletePolicy(fmt.Sprintf("tf-test-%s", rName)),
+				PreConfig: testAccDeleteNewRelicAlertPolicy(fmt.Sprintf("tf-test-%s", rName)),
 				Config:    testAccCheckNewRelicSyntheticsAlertConditionConfig(rName),
 				Check:     testAccCheckNewRelicSyntheticsAlertConditionExists("newrelic_synthetics_alert_condition.foo"),
 			},


### PR DESCRIPTION
Resolves #214.
 
This PR backfills acceptance test coverage for the alert conditions resource and refactors the existing test code for simplicity.