### PR TITLE
Backfill alert policy channel acceptance tests

### DIFF
--- a/newrelic/resource_newrelic_alert_policy_channel.go
+++ b/newrelic/resource_newrelic_alert_policy_channel.go
@@ -32,6 +32,9 @@ func resourceNewRelicAlertPolicyChannel() *schema.Resource {
 		Read:   resourceNewRelicAlertPolicyChannelRead,
 		// Update: Not currently supported in API
 		Delete: resourceNewRelicAlertPolicyChannelDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Schema: map[string]*schema.Schema{
 			"policy_id": {
 				Type:     schema.TypeInt,

--- a/newrelic/resource_newrelic_alert_policy_channel_test.go
+++ b/newrelic/resource_newrelic_alert_policy_channel_test.go
@@ -188,17 +188,3 @@ resource "newrelic_alert_policy_channel" "foo" {
 }
 `, rName)
 }
-
-func testAccDeleteAlertChannel(name string) func() {
-	return func() {
-		client := testAccProvider.Meta().(*ProviderConfig).Client
-		channels, _ := client.ListAlertChannels()
-
-		for _, c := range channels {
-			if c.Name == name {
-				_ = client.DeleteAlertChannel(c.ID)
-				break
-			}
-		}
-	}
-}

--- a/newrelic/resource_newrelic_alert_policy_channel_test.go
+++ b/newrelic/resource_newrelic_alert_policy_channel_test.go
@@ -21,7 +21,7 @@ func TestAccNewRelicAlertPolicyChannel_Basic(t *testing.T) {
 			{
 				Config: testAccNewRelicAlertPolicyChannelConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNewRelicAlertPolicyChannelExists("newrelic_alert_policy_channel.foo"),
+					testAccCheckNewRelicAlertPolicyChannelExists("newrelic_alert_policy_channel.foo"),
 				),
 			},
 			// Test: No diff on re-apply
@@ -31,9 +31,9 @@ func TestAccNewRelicAlertPolicyChannel_Basic(t *testing.T) {
 			},
 			// Test: Update
 			{
-				Config: testAccCheckNewRelicAlertPolicyChannelConfigUpdated(rName),
+				Config: testAccNewRelicAlertPolicyChannelConfigUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNewRelicAlertPolicyChannelExists("newrelic_alert_policy_channel.foo"),
+					testAccCheckNewRelicAlertPolicyChannelExists("newrelic_alert_policy_channel.foo"),
 				),
 			},
 			// Test: Import
@@ -60,6 +60,9 @@ func TestAccNewRelicAlertPolicyChannel_AlertPolicyNotFound(t *testing.T) {
 			{
 				PreConfig: testAccDeleteAlertPolicy(rName),
 				Config:    testAccNewRelicAlertPolicyChannelConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAlertPolicyChannelExists("newrelic_alert_policy_channel.foo"),
+				),
 			},
 		},
 	})
@@ -79,6 +82,9 @@ func TestAccNewRelicAlertPolicyChannel_AlertChannelNotFound(t *testing.T) {
 			{
 				PreConfig: testAccDeleteAlertChannel(rName),
 				Config:    testAccNewRelicAlertPolicyChannelConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAlertPolicyChannelExists("newrelic_alert_policy_channel.foo"),
+				),
 			},
 		},
 	})
@@ -111,7 +117,7 @@ func testAccCheckNewRelicAlertPolicyChannelDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccNewRelicAlertPolicyChannelExists(n string) resource.TestCheckFunc {
+func testAccCheckNewRelicAlertPolicyChannelExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -166,7 +172,7 @@ resource "newrelic_alert_policy_channel" "foo" {
 `, name)
 }
 
-func testAccCheckNewRelicAlertPolicyChannelConfigUpdated(rName string) string {
+func testAccNewRelicAlertPolicyChannelConfigUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "newrelic_alert_policy" "foo" {
   name = "tf-test-updated-%[1]s"

--- a/newrelic/resource_newrelic_alert_policy_channel_test.go
+++ b/newrelic/resource_newrelic_alert_policy_channel_test.go
@@ -19,21 +19,21 @@ func TestAccNewRelicAlertPolicyChannel_Basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test: Create
 			{
-				Config: testAccCheckNewRelicAlertPolicyChannelConfig(rName),
+				Config: testAccNewRelicAlertPolicyChannelConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicAlertPolicyChannelExists("newrelic_alert_policy_channel.foo"),
+					testAccNewRelicAlertPolicyChannelExists("newrelic_alert_policy_channel.foo"),
 				),
 			},
 			// Test: No diff on re-apply
 			{
-				Config:             testAccCheckNewRelicAlertPolicyChannelConfig(rName),
+				Config:             testAccNewRelicAlertPolicyChannelConfig(rName),
 				ExpectNonEmptyPlan: false,
 			},
 			// Test: Update
 			{
 				Config: testAccCheckNewRelicAlertPolicyChannelConfigUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicAlertPolicyChannelExists("newrelic_alert_policy_channel.foo"),
+					testAccNewRelicAlertPolicyChannelExists("newrelic_alert_policy_channel.foo"),
 				),
 			},
 			// Test: Import
@@ -59,7 +59,7 @@ func TestAccNewRelicAlertPolicyChannel_AlertPolicyNotFound(t *testing.T) {
 			},
 			{
 				PreConfig: testAccDeleteAlertPolicy(rName),
-				Config:    testAccCheckNewRelicAlertPolicyChannelConfig(rName),
+				Config:    testAccNewRelicAlertPolicyChannelConfig(rName),
 			},
 		},
 	})
@@ -78,7 +78,7 @@ func TestAccNewRelicAlertPolicyChannel_AlertChannelNotFound(t *testing.T) {
 			},
 			{
 				PreConfig: testAccDeleteAlertChannel(rName),
-				Config:    testAccCheckNewRelicAlertPolicyChannelConfig(rName),
+				Config:    testAccNewRelicAlertPolicyChannelConfig(rName),
 			},
 		},
 	})
@@ -111,7 +111,7 @@ func testAccCheckNewRelicAlertPolicyChannelDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckNewRelicAlertPolicyChannelExists(n string) resource.TestCheckFunc {
+func testAccNewRelicAlertPolicyChannelExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -143,7 +143,7 @@ func testAccCheckNewRelicAlertPolicyChannelExists(n string) resource.TestCheckFu
 	}
 }
 
-func testAccCheckNewRelicAlertPolicyChannelConfig(name string) string {
+func testAccNewRelicAlertPolicyChannelConfig(name string) string {
 	return fmt.Sprintf(`
 resource "newrelic_alert_policy" "foo" {
   name = "%[1]s"


### PR DESCRIPTION
Resolves #216.

This PR introduces importing for the alert policy channel resource, backfills acceptance test coverage, introduces parallel testing, and refactors the existing test code for simplicity.