### PR TITLE
feat: newrelic_nrql_alert_condition acc test updates

### DIFF
--- a/newrelic/helpers.go
+++ b/newrelic/helpers.go
@@ -1,6 +1,7 @@
 package newrelic
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -34,4 +35,12 @@ func serializeIDs(ids []int) string {
 	}
 
 	return strings.Join(idStrings, ":")
+}
+
+// Helper for converting data to pretty JSON
+// nolint:deadcode,unused
+func toJSON(data interface{}) string {
+	c, _ := json.MarshalIndent(data, "", "  ")
+
+	return string(c)
 }

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -11,7 +11,6 @@ import (
 )
 
 func resourceNewRelicNrqlAlertCondition() *schema.Resource {
-
 	return &schema.Resource{
 		Create: resourceNewRelicNrqlAlertConditionCreate,
 		Read:   resourceNewRelicNrqlAlertConditionRead,
@@ -191,13 +190,18 @@ func readNrqlAlertConditionStruct(condition *newrelic.AlertNrqlCondition, d *sch
 	d.Set("name", condition.Name)
 	d.Set("runbook_url", condition.RunbookURL)
 	d.Set("enabled", condition.Enabled)
-	d.Set("nrql.0.Query", condition.Nrql.Query)
-	d.Set("nrql.0.SinceValue", condition.Nrql.SinceValue)
+	d.Set("type", condition.Type)
+	d.Set("expected_groups", condition.ExpectedGroups)
+	d.Set("ignore_overlap", condition.IgnoreOverlap)
 
 	if condition.ValueFunction == "" {
 		d.Set("value_function", "single_value")
 	} else {
 		d.Set("value_function", condition.ValueFunction)
+	}
+
+	if err := d.Set("nrql", flattenNrql(condition.Nrql)); err != nil {
+		return err
 	}
 
 	var terms []map[string]interface{}

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -13,99 +13,66 @@ func TestAccNewRelicNrqlAlertCondition_Basic(t *testing.T) {
 	resourceName := "newrelic_nrql_alert_condition.foo"
 	rName := acctest.RandString(5)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
 		Steps: []resource.TestStep{
+			// Test: Create
 			{
 				Config: testAccNewRelicNrqlAlertConditionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-test-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "runbook_url", "https://foo.example.com"),
-					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "term.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "term.0.duration", "5"),
-					resource.TestCheckResourceAttr(resourceName, "term.0.operator", "below"),
-					resource.TestCheckResourceAttr(resourceName, "term.0.priority", "critical"),
-					resource.TestCheckResourceAttr(resourceName, "term.0.threshold", "0.75"),
-					resource.TestCheckResourceAttr(resourceName, "term.0.time_function", "all"),
-					resource.TestCheckResourceAttr(resourceName, "nrql.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "nrql.0.query", "SELECT uniqueCount(hostname) FROM ComputeSample"),
-					resource.TestCheckResourceAttr(resourceName, "nrql.0.since_value", "20"),
 				),
 			},
+			// Test: No diff on re-apply
+			{
+				Config:             testAccNewRelicNrqlAlertConditionConfig(rName),
+				ExpectNonEmptyPlan: false,
+			},
+			// Test: Update
 			{
 				Config: testAccNewRelicNrqlAlertConditionConfigUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-test-updated-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "runbook_url", "https://bar.example.com"),
-					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "term.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "term.0.duration", "10"),
-					resource.TestCheckResourceAttr(resourceName, "term.0.operator", "below"),
-					resource.TestCheckResourceAttr(resourceName, "term.0.priority", "critical"),
-					resource.TestCheckResourceAttr(resourceName, "term.0.threshold", "0.65"),
-					resource.TestCheckResourceAttr(resourceName, "term.0.time_function", "all"),
-					resource.TestCheckResourceAttr(resourceName, "nrql.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "nrql.0.query", "SELECT uniqueCount(hostname) as Hosts FROM ComputeSample"),
-					resource.TestCheckResourceAttr(resourceName, "nrql.0.since_value", "3"),
 				),
 			},
+			// Test: Import
 			{
-				Config: testAccNewRelicNrqlAlertConditionConfigUpdatedWithStatic(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-test-updated-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "runbook_url", "https://bar.example.com"),
-					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "term.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "term.0.duration", "10"),
-					resource.TestCheckResourceAttr(resourceName, "term.0.operator", "below"),
-					resource.TestCheckResourceAttr(resourceName, "term.0.priority", "critical"),
-					resource.TestCheckResourceAttr(resourceName, "term.0.threshold", "0.65"),
-					resource.TestCheckResourceAttr(resourceName, "term.0.time_function", "all"),
-					resource.TestCheckResourceAttr(resourceName, "nrql.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "nrql.0.query", "SELECT uniqueCount(hostname) as Hosts FROM ComputeSample"),
-					resource.TestCheckResourceAttr(resourceName, "nrql.0.since_value", "3"),
-					resource.TestCheckResourceAttr(resourceName, "type", "static"),
-				),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
-func TestAccNewRelicNrqlAlertCondition_Outlier(t *testing.T) {
+func TestAccNewRelicNrqlAlertCondition_TypeOutlier(t *testing.T) {
 	resourceName := "newrelic_nrql_alert_condition.foo"
 	rName := acctest.RandString(5)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
 		Steps: []resource.TestStep{
+			// Test: Create
 			{
-				Config: testAccNewRelicNrqlAlertConditionConfigWithOutlier(rName),
+				Config: testAccNewRelicNrqlAlertConditionConfigTypeOutlier(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-test-updated-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "runbook_url", "https://bar.example.com"),
-					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "term.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "term.0.duration", "10"),
-					resource.TestCheckResourceAttr(resourceName, "term.0.operator", "above"),
-					resource.TestCheckResourceAttr(resourceName, "term.0.priority", "critical"),
-					resource.TestCheckResourceAttr(resourceName, "term.0.threshold", "0.65"),
-					resource.TestCheckResourceAttr(resourceName, "term.0.time_function", "all"),
-					resource.TestCheckResourceAttr(resourceName, "nrql.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "nrql.0.query", "SELECT percentile(duration, 99) FROM Transaction FACET remote_ip"),
-					resource.TestCheckResourceAttr(resourceName, "nrql.0.since_value", "3"),
-					resource.TestCheckResourceAttr(resourceName, "type", "outlier"),
-					resource.TestCheckResourceAttr(resourceName, "expected_groups", "2"),
-					resource.TestCheckResourceAttr(resourceName, "ignore_overlap", "true"),
 				),
+			},
+			// Test: No diff on re-apply
+			{
+				Config:             testAccNewRelicNrqlAlertConditionConfigTypeOutlier(rName),
+				ExpectNonEmptyPlan: false,
+			},
+			// Test: Import
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -114,7 +81,7 @@ func TestAccNewRelicNrqlAlertCondition_Outlier(t *testing.T) {
 func TestAccNewRelicNrqlAlertCondition_MissingPolicy(t *testing.T) {
 	rName := acctest.RandString(5)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
@@ -130,8 +97,6 @@ func TestAccNewRelicNrqlAlertCondition_MissingPolicy(t *testing.T) {
 		},
 	})
 }
-
-// TODO: func_ TestAccNewRelicNrqlAlertCondition_Multi(t *testing.T) {
 
 func testAccCheckNewRelicNrqlAlertConditionDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*ProviderConfig).Client
@@ -190,9 +155,8 @@ func testAccCheckNewRelicNrqlAlertConditionExists(n string) resource.TestCheckFu
 	}
 }
 
-func testAccNewRelicNrqlAlertConditionConfig(rName string) string {
+func testAccNewRelicNrqlAlertConditionConfig(name string) string {
 	return fmt.Sprintf(`
-
 resource "newrelic_alert_policy" "foo" {
   name = "tf-test-%[1]s"
 }
@@ -210,19 +174,20 @@ resource "newrelic_nrql_alert_condition" "foo" {
     priority      = "critical"
     threshold     = "0.75"
     time_function = "all"
-  }
+	}
+
   nrql {
     query         = "SELECT uniqueCount(hostname) FROM ComputeSample"
     since_value   = "20"
-  }
-  value_function  = "single_value"
+	}
+
+	value_function  = "single_value"
 }
-`, rName)
+`, name)
 }
 
-func testAccNewRelicNrqlAlertConditionConfigUpdated(rName string) string {
+func testAccNewRelicNrqlAlertConditionConfigUpdated(name string) string {
 	return fmt.Sprintf(`
-
 resource "newrelic_alert_policy" "foo" {
   name = "tf-test-%[1]s"
 }
@@ -244,44 +209,13 @@ resource "newrelic_nrql_alert_condition" "foo" {
   nrql {
     query         = "SELECT uniqueCount(hostname) as Hosts FROM ComputeSample"
     since_value   = "3"
-  }
+	}
 }
-`, rName)
+`, name)
 }
 
-func testAccNewRelicNrqlAlertConditionConfigUpdatedWithStatic(rName string) string {
+func testAccNewRelicNrqlAlertConditionConfigTypeOutlier(name string) string {
 	return fmt.Sprintf(`
-
-resource "newrelic_alert_policy" "foo" {
-  name = "tf-test-%[1]s"
-}
-
-resource "newrelic_nrql_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
-
-  name            = "tf-test-updated-%[1]s"
-  runbook_url     = "https://bar.example.com"
-  enabled         = false
-
-  term {
-    duration      = 10
-    operator      = "below"
-    priority      = "critical"
-    threshold     = "0.65"
-    time_function = "all"
-  }
-  nrql {
-    query         = "SELECT uniqueCount(hostname) as Hosts FROM ComputeSample"
-    since_value   = "3"
-  }
-  type = "static"
-}
-`, rName)
-}
-
-func testAccNewRelicNrqlAlertConditionConfigWithOutlier(rName string) string {
-	return fmt.Sprintf(`
-
 resource "newrelic_alert_policy" "foo" {
   name = "tf-test-%[1]s"
 }
@@ -308,7 +242,5 @@ resource "newrelic_nrql_alert_condition" "foo" {
   expected_groups = 2
   ignore_overlap  = true
 }
-`, rName)
+`, name)
 }
-
-// TODO: const testAccCheckNewRelicNrqlAlertConditionConfigMulti = `

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -10,102 +10,67 @@ import (
 )
 
 func TestAccNewRelicNrqlAlertCondition_Basic(t *testing.T) {
+	resourceName := "newrelic_nrql_alert_condition.foo"
 	rName := acctest.RandString(5)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckNewRelicNrqlAlertConditionConfig(rName),
+				Config: testAccNewRelicNrqlAlertConditionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicNrqlAlertConditionExists("newrelic_nrql_alert_condition.foo"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "name", fmt.Sprintf("tf-test-%s", rName)),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "runbook_url", "https://foo.example.com"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "enabled", "false"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.#", "1"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.0.duration", "5"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.0.operator", "below"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.0.priority", "critical"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.0.threshold", "0.75"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.0.time_function", "all"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "nrql.#", "1"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "nrql.0.query", "SELECT uniqueCount(hostname) FROM ComputeSample"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "nrql.0.since_value", "20"),
+					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-test-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "runbook_url", "https://foo.example.com"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "term.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "term.0.duration", "5"),
+					resource.TestCheckResourceAttr(resourceName, "term.0.operator", "below"),
+					resource.TestCheckResourceAttr(resourceName, "term.0.priority", "critical"),
+					resource.TestCheckResourceAttr(resourceName, "term.0.threshold", "0.75"),
+					resource.TestCheckResourceAttr(resourceName, "term.0.time_function", "all"),
+					resource.TestCheckResourceAttr(resourceName, "nrql.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "nrql.0.query", "SELECT uniqueCount(hostname) FROM ComputeSample"),
+					resource.TestCheckResourceAttr(resourceName, "nrql.0.since_value", "20"),
 				),
 			},
 			{
-				Config: testAccCheckNewRelicNrqlAlertConditionConfigUpdated(rName),
+				Config: testAccNewRelicNrqlAlertConditionConfigUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicNrqlAlertConditionExists("newrelic_nrql_alert_condition.foo"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "name", fmt.Sprintf("tf-test-updated-%s", rName)),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "runbook_url", "https://bar.example.com"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "enabled", "false"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.#", "1"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.0.duration", "10"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.0.operator", "below"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.0.priority", "critical"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.0.threshold", "0.65"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.0.time_function", "all"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "nrql.#", "1"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "nrql.0.query", "SELECT uniqueCount(hostname) as Hosts FROM ComputeSample"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "nrql.0.since_value", "3"),
+					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-test-updated-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "runbook_url", "https://bar.example.com"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "term.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "term.0.duration", "10"),
+					resource.TestCheckResourceAttr(resourceName, "term.0.operator", "below"),
+					resource.TestCheckResourceAttr(resourceName, "term.0.priority", "critical"),
+					resource.TestCheckResourceAttr(resourceName, "term.0.threshold", "0.65"),
+					resource.TestCheckResourceAttr(resourceName, "term.0.time_function", "all"),
+					resource.TestCheckResourceAttr(resourceName, "nrql.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "nrql.0.query", "SELECT uniqueCount(hostname) as Hosts FROM ComputeSample"),
+					resource.TestCheckResourceAttr(resourceName, "nrql.0.since_value", "3"),
 				),
 			},
 			{
-				Config: testAccCheckNewRelicNrqlAlertConditionConfigUpdatedWithStatic(rName),
+				Config: testAccNewRelicNrqlAlertConditionConfigUpdatedWithStatic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicNrqlAlertConditionExists("newrelic_nrql_alert_condition.foo"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "name", fmt.Sprintf("tf-test-updated-%s", rName)),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "runbook_url", "https://bar.example.com"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "enabled", "false"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.#", "1"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.0.duration", "10"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.0.operator", "below"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.0.priority", "critical"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.0.threshold", "0.65"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.0.time_function", "all"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "nrql.#", "1"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "nrql.0.query", "SELECT uniqueCount(hostname) as Hosts FROM ComputeSample"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "nrql.0.since_value", "3"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "type", "static"),
+					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-test-updated-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "runbook_url", "https://bar.example.com"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "term.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "term.0.duration", "10"),
+					resource.TestCheckResourceAttr(resourceName, "term.0.operator", "below"),
+					resource.TestCheckResourceAttr(resourceName, "term.0.priority", "critical"),
+					resource.TestCheckResourceAttr(resourceName, "term.0.threshold", "0.65"),
+					resource.TestCheckResourceAttr(resourceName, "term.0.time_function", "all"),
+					resource.TestCheckResourceAttr(resourceName, "nrql.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "nrql.0.query", "SELECT uniqueCount(hostname) as Hosts FROM ComputeSample"),
+					resource.TestCheckResourceAttr(resourceName, "nrql.0.since_value", "3"),
+					resource.TestCheckResourceAttr(resourceName, "type", "static"),
 				),
 			},
 		},
@@ -113,46 +78,33 @@ func TestAccNewRelicNrqlAlertCondition_Basic(t *testing.T) {
 }
 
 func TestAccNewRelicNrqlAlertCondition_Outlier(t *testing.T) {
+	resourceName := "newrelic_nrql_alert_condition.foo"
 	rName := acctest.RandString(5)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckNewRelicNrqlAlertConditionConfigWithOutlier(rName),
+				Config: testAccNewRelicNrqlAlertConditionConfigWithOutlier(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicNrqlAlertConditionExists("newrelic_nrql_alert_condition.foo"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "name", fmt.Sprintf("tf-test-updated-%s", rName)),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "runbook_url", "https://bar.example.com"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "enabled", "false"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.#", "1"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.0.duration", "10"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.0.operator", "above"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.0.priority", "critical"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.0.threshold", "0.65"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "term.0.time_function", "all"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "nrql.#", "1"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "nrql.0.query", "SELECT percentile(duration, 99) FROM Transaction FACET remote_ip"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "nrql.0.since_value", "3"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "type", "outlier"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "expected_groups", "2"),
-					resource.TestCheckResourceAttr(
-						"newrelic_nrql_alert_condition.foo", "ignore_overlap", "true"),
+					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-test-updated-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "runbook_url", "https://bar.example.com"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "term.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "term.0.duration", "10"),
+					resource.TestCheckResourceAttr(resourceName, "term.0.operator", "above"),
+					resource.TestCheckResourceAttr(resourceName, "term.0.priority", "critical"),
+					resource.TestCheckResourceAttr(resourceName, "term.0.threshold", "0.65"),
+					resource.TestCheckResourceAttr(resourceName, "term.0.time_function", "all"),
+					resource.TestCheckResourceAttr(resourceName, "nrql.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "nrql.0.query", "SELECT percentile(duration, 99) FROM Transaction FACET remote_ip"),
+					resource.TestCheckResourceAttr(resourceName, "nrql.0.since_value", "3"),
+					resource.TestCheckResourceAttr(resourceName, "type", "outlier"),
+					resource.TestCheckResourceAttr(resourceName, "expected_groups", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ignore_overlap", "true"),
 				),
 			},
 		},
@@ -168,11 +120,11 @@ func TestAccNewRelicNrqlAlertCondition_MissingPolicy(t *testing.T) {
 		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckNewRelicNrqlAlertConditionConfig(rName),
+				Config: testAccNewRelicNrqlAlertConditionConfig(rName),
 			},
 			{
 				PreConfig: testAccDeleteNewRelicAlertPolicy(fmt.Sprintf("tf-test-%s", rName)),
-				Config:    testAccCheckNewRelicNrqlAlertConditionConfig(rName),
+				Config:    testAccNewRelicNrqlAlertConditionConfig(rName),
 				Check:     testAccCheckNewRelicNrqlAlertConditionExists("newrelic_nrql_alert_condition.foo"),
 			},
 		},
@@ -238,7 +190,7 @@ func testAccCheckNewRelicNrqlAlertConditionExists(n string) resource.TestCheckFu
 	}
 }
 
-func testAccCheckNewRelicNrqlAlertConditionConfig(rName string) string {
+func testAccNewRelicNrqlAlertConditionConfig(rName string) string {
 	return fmt.Sprintf(`
 
 resource "newrelic_alert_policy" "foo" {
@@ -268,7 +220,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
 `, rName)
 }
 
-func testAccCheckNewRelicNrqlAlertConditionConfigUpdated(rName string) string {
+func testAccNewRelicNrqlAlertConditionConfigUpdated(rName string) string {
 	return fmt.Sprintf(`
 
 resource "newrelic_alert_policy" "foo" {
@@ -297,7 +249,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
 `, rName)
 }
 
-func testAccCheckNewRelicNrqlAlertConditionConfigUpdatedWithStatic(rName string) string {
+func testAccNewRelicNrqlAlertConditionConfigUpdatedWithStatic(rName string) string {
 	return fmt.Sprintf(`
 
 resource "newrelic_alert_policy" "foo" {
@@ -327,7 +279,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
 `, rName)
 }
 
-func testAccCheckNewRelicNrqlAlertConditionConfigWithOutlier(rName string) string {
+func testAccNewRelicNrqlAlertConditionConfigWithOutlier(rName string) string {
 	return fmt.Sprintf(`
 
 resource "newrelic_alert_policy" "foo" {

--- a/newrelic/structure_newrelic_nrql_alert_condition.go
+++ b/newrelic/structure_newrelic_nrql_alert_condition.go
@@ -1,0 +1,14 @@
+package newrelic
+
+import (
+	newrelic "github.com/paultyng/go-newrelic/v4/api"
+)
+
+func flattenNrql(nrql newrelic.AlertNrqlQuery) []interface{} {
+	m := map[string]interface{}{
+		"query":       nrql.Query,
+		"since_value": nrql.SinceValue,
+	}
+
+	return []interface{}{m}
+}

--- a/newrelic/structure_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/structure_newrelic_nrql_alert_condition_test.go
@@ -1,0 +1,30 @@
+package newrelic
+
+import (
+	"reflect"
+	"testing"
+
+	newrelic "github.com/paultyng/go-newrelic/v4/api"
+)
+
+func TestFlattenNrql(t *testing.T) {
+	expanded := newrelic.AlertNrqlQuery{
+		Query:      "SELECT percentile(duration, 99) FROM Transaction FACET remote_ip",
+		SinceValue: "3",
+	}
+
+	flattened := []interface{}{map[string]interface{}{
+		"query":       "SELECT percentile(duration, 99) FROM Transaction FACET remote_ip",
+		"since_value": "3",
+	}}
+
+	result := flattenNrql(expanded)
+
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+
+	if !reflect.DeepEqual(result, flattened) {
+		t.Fatalf("result %s not equal to expected %s", result, flattened)
+	}
+}

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -10,6 +10,7 @@ description: |-
 
 ## Example Usage
 
+##### Type: `static` (default)
 ```hcl
 resource "newrelic_alert_policy" "foo" {
   name = "foo"
@@ -39,6 +40,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
   value_function = "single_value"
 }
 ```
+See additional [examples](#additional-examples).
 
 ## Argument Reference
 
@@ -46,9 +48,9 @@ The following arguments are supported:
 
 - `policy_id` - (Required) The ID of the policy where this condition should be used.
 - `name` - (Required) The title of the condition
-- `type` - (Optional) The type of the condition. One of `static`, `outlier`, or `baseline`. Defaults to `static`.
+- `type` - (Optional) The type of the condition. Valid values are `static` or `outlier`. Defaults to `static`.
 - `runbook_url` - (Optional) Runbook URL to display in notifications.
-- `enabled` - (Optional) Set whether to enable the alert condition. Defaults to `true`.
+- `enabled` - (Optional) Whether to enable the alert condition. Valid values are `true` and `false`. Defaults to `true`.
 - `term` - (Required) A list of terms for this condition. See [Terms](#terms) below for details.
 - `nrql` - (Required) A NRQL query. See [NRQL](#nrql) below for details.
 - `value_function` - (Optional) Possible values are `single_value`, `sum`.
@@ -77,6 +79,38 @@ The `nrql` attribute supports the following arguments:
 The following attributes are exported:
 
 - `id` - The ID of the NRQL alert condition.
+
+## Additional Examples
+
+##### Type: `outlier`
+```hcl
+resource "newrelic_alert_policy" "foo" {
+  name = "foo"
+}
+
+resource "newrelic_nrql_alert_condition" "foo" {
+  policy_id = "${newrelic_alert_policy.foo.id}"
+
+  name        = "outlier-example"
+  runbook_url = "https://bar.example.com"
+  enabled     = true
+
+  term {
+    duration      = 10
+    operator      = "above"
+    priority      = "critical"
+    threshold     = "0.65"
+    time_function = "all"
+  }
+  nrql {
+    query       = "SELECT percentile(duration, 99) FROM Transaction FACET remote_ip"
+    since_value = "3"
+  }
+  type            = "outlier"
+  expected_groups = 2
+  ignore_overlap  = true
+}
+```
 
 ## Import
 


### PR DESCRIPTION
Resolves: #219 

IMPROVEMENTS:
- add ability to import `newrelic_nrql_alert_condition`
    - Note: this only for types `static` and `outlier` (type `baseline` is not enabled yet)
- additional acceptance test coverage of `newrelic_nrql_alert_condition`