### PR TITLE
Acc testing infra conditions

### DIFF
--- a/newrelic/resource_newrelic_infra_alert_condition.go
+++ b/newrelic/resource_newrelic_infra_alert_condition.go
@@ -10,16 +10,16 @@ import (
 
 var thresholdConditionTypes = map[string][]string{
 	"infra_process_running": {
-		"duration_minutes",
+		"duration",
 		"value",
 	},
 	"infra_metric": {
-		"duration_minutes",
+		"duration",
 		"value",
 		"time_function",
 	},
 	"infra_host_not_reporting": {
-		"duration_minutes",
+		"duration",
 	},
 }
 

--- a/newrelic/resource_newrelic_infra_alert_condition.go
+++ b/newrelic/resource_newrelic_infra_alert_condition.go
@@ -186,6 +186,10 @@ func readInfraAlertConditionStruct(condition *newrelic.AlertInfraCondition, d *s
 	d.Set("name", condition.Name)
 	d.Set("runbook_url", condition.RunbookURL)
 	d.Set("enabled", condition.Enabled)
+	d.Set("comparison", condition.Comparison)
+	d.Set("event", condition.Event)
+	d.Set("select", condition.Select)
+	d.Set("type", condition.Type)
 	d.Set("created_at", condition.CreatedAt)
 	d.Set("updated_at", condition.UpdatedAt)
 

--- a/newrelic/resource_newrelic_infra_alert_condition_test.go
+++ b/newrelic/resource_newrelic_infra_alert_condition_test.go
@@ -12,7 +12,7 @@ import (
 func TestAccNewRelicInfraAlertCondition_Basic(t *testing.T) {
 	resourceName := "newrelic_infra_alert_condition.foo"
 	rName := acctest.RandString(5)
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicInfraAlertConditionDestroy,
@@ -51,7 +51,7 @@ func TestAccNewRelicInfraAlertCondition_Where(t *testing.T) {
 	resourceName := "newrelic_infra_alert_condition.foo"
 	rName := acctest.RandString(5)
 	whereClause := "(`hostname` LIKE '%cassandra%')"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicInfraAlertConditionDestroy,
@@ -82,7 +82,7 @@ func TestAccNewRelicInfraAlertCondition_IntegrationProvider(t *testing.T) {
 	rName := acctest.RandString(5)
 	resourceName := "newrelic_infra_alert_condition.foo"
 	integrationProvider := "Elb"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicInfraAlertConditionDestroy,
@@ -111,7 +111,7 @@ func TestAccNewRelicInfraAlertCondition_IntegrationProvider(t *testing.T) {
 func TestAccNewRelicInfraAlertCondition_Thresholds(t *testing.T) {
 	resourceName := "newrelic_infra_alert_condition.foo"
 	rName := acctest.RandString(5)
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicInfraAlertConditionDestroy,
@@ -150,7 +150,7 @@ func TestAccNewRelicInfraAlertCondition_Thresholds(t *testing.T) {
 func TestAccNewRelicInfraAlertCondition_MissingPolicy(t *testing.T) {
 	rName := acctest.RandString(5)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicInfraAlertConditionDestroy,

--- a/newrelic/resource_newrelic_infra_alert_condition_test.go
+++ b/newrelic/resource_newrelic_infra_alert_condition_test.go
@@ -82,6 +82,10 @@ func TestAccNewRelicInfraAlertCondition_Where(t *testing.T) {
 }
 
 func TestAccNewRelicInfraAlertCondition_IntegrationProvider(t *testing.T) {
+	if !nrInternalAccount {
+		t.Skipf("New Relic internal testing account required")
+	}
+
 	rand := acctest.RandString(5)
 	rName := fmt.Sprintf("tf-test-%s", rand)
 	resourceName := "newrelic_infra_alert_condition.foo"

--- a/newrelic/resource_newrelic_infra_alert_condition_test.go
+++ b/newrelic/resource_newrelic_infra_alert_condition_test.go
@@ -11,7 +11,9 @@ import (
 
 func TestAccNewRelicInfraAlertCondition_Basic(t *testing.T) {
 	resourceName := "newrelic_infra_alert_condition.foo"
-	rName := acctest.RandString(5)
+	rand := acctest.RandString(5)
+	rName := fmt.Sprintf("tf-test-%s", rand)
+	rNameUpdated := fmt.Sprintf("tf-test-updated-%s", rand)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -25,14 +27,14 @@ func TestAccNewRelicInfraAlertCondition_Basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr("newrelic_infra_alert_condition.foo", "warning"),
 				),
 			},
-			// Test: No diff on reapply
+			// Test: No diff on re-apply
 			{
 				Config:             testAccCheckNewRelicInfraAlertConditionConfig(rName),
 				ExpectNonEmptyPlan: false,
 			},
 			// Test: Update
 			{
-				Config: testAccCheckNewRelicInfraAlertConditionConfigUpdated(rName),
+				Config: testAccCheckNewRelicInfraAlertConditionConfigUpdated(rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicInfraAlertConditionExists(resourceName),
 				),
@@ -49,7 +51,8 @@ func TestAccNewRelicInfraAlertCondition_Basic(t *testing.T) {
 
 func TestAccNewRelicInfraAlertCondition_Where(t *testing.T) {
 	resourceName := "newrelic_infra_alert_condition.foo"
-	rName := acctest.RandString(5)
+	rand := acctest.RandString(5)
+	rName := fmt.Sprintf("tf-test-%s", rand)
 	whereClause := "(`hostname` LIKE '%cassandra%')"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -63,7 +66,7 @@ func TestAccNewRelicInfraAlertCondition_Where(t *testing.T) {
 					testAccCheckNewRelicInfraAlertConditionExists(resourceName),
 				),
 			},
-			// Test: No diff on reapply
+			// Test: No diff on re-apply
 			{
 				Config:             testAccCheckNewRelicInfraAlertConditionConfigWithWhere(rName, whereClause),
 				ExpectNonEmptyPlan: false,
@@ -79,7 +82,8 @@ func TestAccNewRelicInfraAlertCondition_Where(t *testing.T) {
 }
 
 func TestAccNewRelicInfraAlertCondition_IntegrationProvider(t *testing.T) {
-	rName := acctest.RandString(5)
+	rand := acctest.RandString(5)
+	rName := fmt.Sprintf("tf-test-%s", rand)
 	resourceName := "newrelic_infra_alert_condition.foo"
 	integrationProvider := "Elb"
 	resource.ParallelTest(t, resource.TestCase{
@@ -91,7 +95,7 @@ func TestAccNewRelicInfraAlertCondition_IntegrationProvider(t *testing.T) {
 			{
 				Config: testAccCheckNewRelicInfraAlertConditionConfigWithIntegrationProvider(rName, integrationProvider),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicInfraAlertConditionExists("newrelic_infra_alert_condition.foo"),
+					testAccCheckNewRelicInfraAlertConditionExists(resourceName),
 				),
 			},
 			// Test: No diff on re-apply
@@ -110,7 +114,8 @@ func TestAccNewRelicInfraAlertCondition_IntegrationProvider(t *testing.T) {
 }
 func TestAccNewRelicInfraAlertCondition_Thresholds(t *testing.T) {
 	resourceName := "newrelic_infra_alert_condition.foo"
-	rName := acctest.RandString(5)
+	rand := acctest.RandString(5)
+	rName := fmt.Sprintf("tf-test-%s", rand)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -148,7 +153,8 @@ func TestAccNewRelicInfraAlertCondition_Thresholds(t *testing.T) {
 }
 
 func TestAccNewRelicInfraAlertCondition_MissingPolicy(t *testing.T) {
-	rName := acctest.RandString(5)
+	rand := acctest.RandString(5)
+	rName := fmt.Sprintf("tf-test-%s", rand)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -224,17 +230,17 @@ func testAccCheckNewRelicInfraAlertConditionExists(n string) resource.TestCheckF
 	}
 }
 
-func testAccCheckNewRelicInfraAlertConditionConfig(rName string) string {
+func testAccCheckNewRelicInfraAlertConditionConfig(name string) string {
 	return fmt.Sprintf(`
 
 resource "newrelic_alert_policy" "foo" {
-  name = "tf-test-%[1]s"
+  name = "%[1]s"
 }
 
 resource "newrelic_infra_alert_condition" "foo" {
   policy_id = "${newrelic_alert_policy.foo.id}"
 
-  name            = "tf-test-%[1]s"
+  name            = "%[1]s"
   runbook_url     = "https://foo.example.com"
   type            = "infra_metric"
   event           = "StorageSample"
@@ -247,19 +253,19 @@ resource "newrelic_infra_alert_condition" "foo" {
 	  time_function = "any"
   }
 }
-`, rName)
+`, name)
 }
 
-func testAccCheckNewRelicInfraAlertConditionConfigUpdated(rName string) string {
+func testAccCheckNewRelicInfraAlertConditionConfigUpdated(name string) string {
 	return fmt.Sprintf(`
 resource "newrelic_alert_policy" "foo" {
-  name = "tf-test-%[1]s"
+  name = "%[1]s"
 }
 
 resource "newrelic_infra_alert_condition" "foo" {
   policy_id = "${newrelic_alert_policy.foo.id}"
 
-  name            = "tf-test-updated-%[1]s"
+  name            = "%[1]s"
   runbook_url     = "https://bar.example.com"
   type            = "infra_metric"
   event           = "StorageSample"
@@ -272,19 +278,19 @@ resource "newrelic_infra_alert_condition" "foo" {
 	  time_function = "any"
   }
 }
-`, rName)
+`, name)
 }
 
-func testAccCheckNewRelicInfraAlertConditionConfigWithThreshold(rName string) string {
+func testAccCheckNewRelicInfraAlertConditionConfigWithThreshold(name string) string {
 	return fmt.Sprintf(`
 resource "newrelic_alert_policy" "foo" {
-  name = "tf-test-%[1]s"
+  name = "%[1]s"
 }
 
 resource "newrelic_infra_alert_condition" "foo" {
   policy_id = "${newrelic_alert_policy.foo.id}"
 
-  name            = "tf-test-%[1]s"
+  name            = "%[1]s"
   type            = "infra_metric"
   event           = "StorageSample"
   select          = "diskFreePercent"
@@ -302,19 +308,19 @@ resource "newrelic_infra_alert_condition" "foo" {
 	time_function = "any"
   }
 }
-`, rName)
+`, name)
 }
 
-func testAccCheckNewRelicInfraAlertConditionConfigWithThresholdUpdated(rName string) string {
+func testAccCheckNewRelicInfraAlertConditionConfigWithThresholdUpdated(name string) string {
 	return fmt.Sprintf(`
 resource "newrelic_alert_policy" "foo" {
-  name = "tf-test-%[1]s"
+  name = "%[1]s"
 }
 
 resource "newrelic_infra_alert_condition" "foo" {
   policy_id = "${newrelic_alert_policy.foo.id}"
 
-  name            = "tf-test-%[1]s"
+  name            = "%[1]s"
   type            = "infra_metric"
   event           = "StorageSample"
   select          = "diskFreePercent"
@@ -326,19 +332,19 @@ resource "newrelic_infra_alert_condition" "foo" {
 	time_function = "all"
   }
 }
-`, rName)
+`, name)
 }
 
-func testAccCheckNewRelicInfraAlertConditionConfigWithWhere(rName, where string) string {
+func testAccCheckNewRelicInfraAlertConditionConfigWithWhere(name, where string) string {
 	return fmt.Sprintf(`
 resource "newrelic_alert_policy" "foo" {
-  name = "tf-test-%[1]s"
+  name = "%[1]s"
 }
 
 resource "newrelic_infra_alert_condition" "foo" {
   policy_id = "${newrelic_alert_policy.foo.id}"
 
-  name          = "tf-test-%[1]s"
+  name          = "%[1]s"
   type          = "infra_process_running"
   process_where = "commandName = 'java'"
   comparison    = "equal"
@@ -349,19 +355,19 @@ resource "newrelic_infra_alert_condition" "foo" {
 	value = 0
   }
 }
-`, rName, where)
+`, name, where)
 }
 
-func testAccCheckNewRelicInfraAlertConditionConfigWithIntegrationProvider(rName, integrationProvider string) string {
+func testAccCheckNewRelicInfraAlertConditionConfigWithIntegrationProvider(name, integrationProvider string) string {
 	return fmt.Sprintf(`
 resource "newrelic_alert_policy" "foo" {
-  name = "tf-test-%[1]s"
+  name = "%[1]s"
 }
 
 resource "newrelic_infra_alert_condition" "foo" {
   policy_id = "${newrelic_alert_policy.foo.id}"
 
-  name                 = "tf-test-%[1]s"
+  name                 = "%[1]s"
   type                 = "infra_metric"
   event                = "LoadBalancerSample"
   integration_provider = "%[2]s"
@@ -374,5 +380,5 @@ resource "newrelic_infra_alert_condition" "foo" {
     time_function = "all"
   }
 }
-`, rName, integrationProvider)
+`, name, integrationProvider)
 }

--- a/newrelic/resource_newrelic_infra_alert_condition_test.go
+++ b/newrelic/resource_newrelic_infra_alert_condition_test.go
@@ -21,7 +21,7 @@ func TestAccNewRelicInfraAlertCondition_Basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test: Create
 			{
-				Config: testAccCheckNewRelicInfraAlertConditionConfig(rName),
+				Config: testAccNewRelicInfraAlertConditionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicInfraAlertConditionExists(resourceName),
 					resource.TestCheckNoResourceAttr("newrelic_infra_alert_condition.foo", "warning"),
@@ -29,12 +29,12 @@ func TestAccNewRelicInfraAlertCondition_Basic(t *testing.T) {
 			},
 			// Test: No diff on re-apply
 			{
-				Config:             testAccCheckNewRelicInfraAlertConditionConfig(rName),
+				Config:             testAccNewRelicInfraAlertConditionConfig(rName),
 				ExpectNonEmptyPlan: false,
 			},
 			// Test: Update
 			{
-				Config: testAccCheckNewRelicInfraAlertConditionConfigUpdated(rNameUpdated),
+				Config: testAccNewRelicInfraAlertConditionConfigUpdated(rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicInfraAlertConditionExists(resourceName),
 				),
@@ -61,14 +61,14 @@ func TestAccNewRelicInfraAlertCondition_Where(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test: Create
 			{
-				Config: testAccCheckNewRelicInfraAlertConditionConfigWithWhere(rName, whereClause),
+				Config: testAccNewRelicInfraAlertConditionConfigWithWhere(rName, whereClause),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicInfraAlertConditionExists(resourceName),
 				),
 			},
 			// Test: No diff on re-apply
 			{
-				Config:             testAccCheckNewRelicInfraAlertConditionConfigWithWhere(rName, whereClause),
+				Config:             testAccNewRelicInfraAlertConditionConfigWithWhere(rName, whereClause),
 				ExpectNonEmptyPlan: false,
 			},
 			// Test: Import
@@ -97,14 +97,14 @@ func TestAccNewRelicInfraAlertCondition_IntegrationProvider(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test: Create
 			{
-				Config: testAccCheckNewRelicInfraAlertConditionConfigWithIntegrationProvider(rName, integrationProvider),
+				Config: testAccNewRelicInfraAlertConditionConfigWithIntegrationProvider(rName, integrationProvider),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicInfraAlertConditionExists(resourceName),
 				),
 			},
 			// Test: No diff on re-apply
 			{
-				Config:             testAccCheckNewRelicInfraAlertConditionConfigWithIntegrationProvider(rName, integrationProvider),
+				Config:             testAccNewRelicInfraAlertConditionConfigWithIntegrationProvider(rName, integrationProvider),
 				ExpectNonEmptyPlan: false,
 			},
 			// Test: Import
@@ -127,14 +127,14 @@ func TestAccNewRelicInfraAlertCondition_Thresholds(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test: Create
 			{
-				Config: testAccCheckNewRelicInfraAlertConditionConfigWithThreshold(rName),
+				Config: testAccNewRelicInfraAlertConditionConfigWithThreshold(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicInfraAlertConditionExists(resourceName),
 				),
 			},
 			// Test: No diff on re-apply
 			{
-				Config:             testAccCheckNewRelicInfraAlertConditionConfigWithThreshold(rName),
+				Config:             testAccNewRelicInfraAlertConditionConfigWithThreshold(rName),
 				ExpectNonEmptyPlan: false,
 			},
 			// Test: Update
@@ -166,11 +166,11 @@ func TestAccNewRelicInfraAlertCondition_MissingPolicy(t *testing.T) {
 		CheckDestroy: testAccCheckNewRelicInfraAlertConditionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckNewRelicInfraAlertConditionConfig(rName),
+				Config: testAccNewRelicInfraAlertConditionConfig(rName),
 			},
 			{
 				PreConfig: testAccDeleteNewRelicAlertPolicy(fmt.Sprintf("tf-test-%s", rName)),
-				Config:    testAccCheckNewRelicInfraAlertConditionConfig(rName),
+				Config:    testAccNewRelicInfraAlertConditionConfig(rName),
 				Check:     testAccCheckNewRelicInfraAlertConditionExists("newrelic_infra_alert_condition.foo"),
 			},
 		},
@@ -234,7 +234,7 @@ func testAccCheckNewRelicInfraAlertConditionExists(n string) resource.TestCheckF
 	}
 }
 
-func testAccCheckNewRelicInfraAlertConditionConfig(name string) string {
+func testAccNewRelicInfraAlertConditionConfig(name string) string {
 	return fmt.Sprintf(`
 
 resource "newrelic_alert_policy" "foo" {
@@ -260,7 +260,7 @@ resource "newrelic_infra_alert_condition" "foo" {
 `, name)
 }
 
-func testAccCheckNewRelicInfraAlertConditionConfigUpdated(name string) string {
+func testAccNewRelicInfraAlertConditionConfigUpdated(name string) string {
 	return fmt.Sprintf(`
 resource "newrelic_alert_policy" "foo" {
   name = "%[1]s"
@@ -285,7 +285,7 @@ resource "newrelic_infra_alert_condition" "foo" {
 `, name)
 }
 
-func testAccCheckNewRelicInfraAlertConditionConfigWithThreshold(name string) string {
+func testAccNewRelicInfraAlertConditionConfigWithThreshold(name string) string {
 	return fmt.Sprintf(`
 resource "newrelic_alert_policy" "foo" {
   name = "%[1]s"
@@ -339,7 +339,7 @@ resource "newrelic_infra_alert_condition" "foo" {
 `, name)
 }
 
-func testAccCheckNewRelicInfraAlertConditionConfigWithWhere(name, where string) string {
+func testAccNewRelicInfraAlertConditionConfigWithWhere(name, where string) string {
 	return fmt.Sprintf(`
 resource "newrelic_alert_policy" "foo" {
   name = "%[1]s"
@@ -362,7 +362,7 @@ resource "newrelic_infra_alert_condition" "foo" {
 `, name, where)
 }
 
-func testAccCheckNewRelicInfraAlertConditionConfigWithIntegrationProvider(name, integrationProvider string) string {
+func testAccNewRelicInfraAlertConditionConfigWithIntegrationProvider(name, integrationProvider string) string {
 	return fmt.Sprintf(`
 resource "newrelic_alert_policy" "foo" {
   name = "%[1]s"

--- a/newrelic/resource_newrelic_infra_alert_condition_test.go
+++ b/newrelic/resource_newrelic_infra_alert_condition_test.go
@@ -2,7 +2,6 @@ package newrelic
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -11,41 +10,45 @@ import (
 )
 
 func TestAccNewRelicInfraAlertCondition_Basic(t *testing.T) {
+	resourceName := "newrelic_infra_alert_condition.foo"
 	rName := acctest.RandString(5)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicInfraAlertConditionDestroy,
 		Steps: []resource.TestStep{
+			// Test: Create
 			{
 				Config: testAccCheckNewRelicInfraAlertConditionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicInfraAlertConditionExists("newrelic_infra_alert_condition.foo"),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "name", fmt.Sprintf("tf-test-%s", rName)),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "runbook_url", "https://foo.example.com"),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "critical.0.duration", "10"),
-					resource.TestCheckNoResourceAttr(
-						"newrelic_infra_alert_condition.foo", "warning"),
+					testAccCheckNewRelicInfraAlertConditionExists(resourceName),
+					resource.TestCheckNoResourceAttr("newrelic_infra_alert_condition.foo", "warning"),
 				),
 			},
+			// Test: No diff on reapply
+			{
+				Config:             testAccCheckNewRelicInfraAlertConditionConfig(rName),
+				ExpectNonEmptyPlan: false,
+			},
+			// Test: Update
 			{
 				Config: testAccCheckNewRelicInfraAlertConditionConfigUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicInfraAlertConditionExists("newrelic_infra_alert_condition.foo"),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "name", fmt.Sprintf("tf-test-updated-%s", rName)),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "runbook_url", "https://bar.example.com"),
+					testAccCheckNewRelicInfraAlertConditionExists(resourceName),
 				),
+			},
+			// Test: Import
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccNewRelicInfraAlertCondition_Where(t *testing.T) {
+	resourceName := "newrelic_infra_alert_condition.foo"
 	rName := acctest.RandString(5)
 	whereClause := "(`hostname` LIKE '%cassandra%')"
 	resource.Test(t, resource.TestCase{
@@ -53,99 +56,92 @@ func TestAccNewRelicInfraAlertCondition_Where(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicInfraAlertConditionDestroy,
 		Steps: []resource.TestStep{
+			// Test: Create
 			{
 				Config: testAccCheckNewRelicInfraAlertConditionConfigWithWhere(rName, whereClause),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicInfraAlertConditionExists("newrelic_infra_alert_condition.foo"),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "name", fmt.Sprintf("tf-test-%s", rName)),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "critical.0.duration", "10"),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "critical.0.value", "0"),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "where", whereClause),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "process_where", "commandName = 'java'"),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "comparison", "equal"),
+					testAccCheckNewRelicInfraAlertConditionExists(resourceName),
 				),
+			},
+			// Test: No diff on reapply
+			{
+				Config:             testAccCheckNewRelicInfraAlertConditionConfigWithWhere(rName, whereClause),
+				ExpectNonEmptyPlan: false,
+			},
+			// Test: Import
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccNewRelicInfraAlertCondition_IntegrationProvider(t *testing.T) {
-	key := "ENABLE_NEWRELIC_INTEGRATION_PROVIDER"
-	enableNewRelicIntegrationProvider := os.Getenv(key)
-	if enableNewRelicIntegrationProvider == "" {
-		t.Skipf("Environment variable %s is not set", key)
-	}
-
 	rName := acctest.RandString(5)
+	resourceName := "newrelic_infra_alert_condition.foo"
 	integrationProvider := "Elb"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicInfraAlertConditionDestroy,
 		Steps: []resource.TestStep{
+			// Test: Create
 			{
 				Config: testAccCheckNewRelicInfraAlertConditionConfigWithIntegrationProvider(rName, integrationProvider),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicInfraAlertConditionExists("newrelic_infra_alert_condition.foo"),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "name", fmt.Sprintf("tf-test-%s", rName)),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "critical.0.duration", "10"),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "critical.0.value", "1"),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "integration_provider", integrationProvider),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "comparison", "below"),
 				),
+			},
+			// Test: No diff on re-apply
+			{
+				Config:             testAccCheckNewRelicInfraAlertConditionConfigWithIntegrationProvider(rName, integrationProvider),
+				ExpectNonEmptyPlan: false,
+			},
+			// Test: Import
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 func TestAccNewRelicInfraAlertCondition_Thresholds(t *testing.T) {
+	resourceName := "newrelic_infra_alert_condition.foo"
 	rName := acctest.RandString(5)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicInfraAlertConditionDestroy,
 		Steps: []resource.TestStep{
+			// Test: Create
 			{
 				Config: testAccCheckNewRelicInfraAlertConditionConfigWithThreshold(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicInfraAlertConditionExists("newrelic_infra_alert_condition.foo"),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "name", fmt.Sprintf("tf-test-%s", rName)),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "critical.0.duration", "10"),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "critical.0.value", "10"),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "critical.0.time_function", "any"),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "warning.0.value", "20"),
+					testAccCheckNewRelicInfraAlertConditionExists(resourceName),
 				),
 			},
+			// Test: No diff on re-apply
+			{
+				Config:             testAccCheckNewRelicInfraAlertConditionConfigWithThreshold(rName),
+				ExpectNonEmptyPlan: false,
+			},
+			// Test: Update
 			{
 				Config: testAccCheckNewRelicInfraAlertConditionConfigWithThresholdUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicInfraAlertConditionExists("newrelic_infra_alert_condition.foo"),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "name", fmt.Sprintf("tf-test-%s", rName)),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "critical.0.duration", "20"),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "critical.0.value", "15"),
-					resource.TestCheckResourceAttr(
-						"newrelic_infra_alert_condition.foo", "critical.0.time_function", "all"),
+					testAccCheckNewRelicInfraAlertConditionExists(resourceName),
 					resource.TestCheckNoResourceAttr(
 						"newrelic_infra_alert_condition.foo", "warning"),
 				),
+			},
+			// Test: Import
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
Resolves #220.

This PR introduces import for the `newrelic_infra_alert_condition` resource type, parallelizes its acceptance tests, refreshes its documentation, and backfills acceptance test coverage.