### PR TITLE
feat: update newrelic_synthetics_monitor acceptance tests

### DIFF
--- a/newrelic/resource_newrelic_synthetics_monitor_test.go
+++ b/newrelic/resource_newrelic_synthetics_monitor_test.go
@@ -13,7 +13,7 @@ func TestAccNewRelicSyntheticsMonitor_Basic(t *testing.T) {
 	resourceName := "newrelic_synthetics_monitor.foo"
 	rName := acctest.RandString(5)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicSyntheticsMonitorDestroy,
@@ -33,6 +33,44 @@ func TestAccNewRelicSyntheticsMonitor_Basic(t *testing.T) {
 			// Test: Update
 			{
 				Config: testAccNewRelicSyntheticsMonitorConfigUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicSyntheticsMonitorExists(resourceName),
+				),
+			},
+			// Test: Import
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccNewRelicSyntheticsMonitor_Browser(t *testing.T) {
+	resourceName := "newrelic_synthetics_monitor.foo"
+	rName := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicSyntheticsMonitorDestroy,
+		Steps: []resource.TestStep{
+			// Test: Create
+			{
+				Config: testAccNewRelicSyntheticsMonitorConfigBrowser(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicSyntheticsMonitorExists(resourceName),
+				),
+			},
+			// Test: No diff on re-apply
+			{
+				Config:             testAccNewRelicSyntheticsMonitorConfigBrowser(rName),
+				ExpectNonEmptyPlan: false,
+			},
+			// Test: Update
+			{
+				Config: testAccNewRelicSyntheticsMonitorConfigBrowserUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicSyntheticsMonitorExists(resourceName),
 				),
@@ -91,12 +129,17 @@ func testAccCheckNewRelicSyntheticsMonitorDestroy(s *terraform.State) error {
 func testAccNewRelicSyntheticsMonitorConfig(name string) string {
 	return fmt.Sprintf(`
 resource "newrelic_synthetics_monitor" "foo" {
-	name      = "%[1]s"
-	type      = "SIMPLE"
-	frequency = 1
-	status    = "DISABLED"
-	locations = ["AWS_US_EAST_1"]
-	uri       = "https://google.com"
+	name       = "%[1]s"
+	type       = "SIMPLE"
+	frequency  = 1
+	status     = "DISABLED"
+	locations  = ["AWS_US_EAST_1"]
+
+	uri                       = "https://example.com"
+	validation_string         = "add example validation check here"
+	verify_ssl                = false
+	bypass_head_request       = false
+	treat_redirect_as_failure = false
 }
 `, name)
 }
@@ -109,7 +152,44 @@ resource "newrelic_synthetics_monitor" "foo" {
 	frequency = 5
 	status    = "ENABLED"
 	locations = ["AWS_US_EAST_1", "AWS_US_WEST_1"]
-	uri       = "https://github.com"
+
+	uri                       = "https://example-updated.com"
+	validation_string         = "add example validation check here updated"
+	verify_ssl                = true
+	bypass_head_request       = true
+	treat_redirect_as_failure = true
+}
+`, name)
+}
+
+func testAccNewRelicSyntheticsMonitorConfigBrowser(name string) string {
+	return fmt.Sprintf(`
+resource "newrelic_synthetics_monitor" "foo" {
+	name      = "%[1]s-browser-test"
+	type      = "BROWSER"
+	frequency = 1
+	status    = "DISABLED"
+	locations = ["AWS_US_EAST_1"]
+
+	uri                       = "https://example.com"
+	validation_string         = "this text should exist in the response"
+	verify_ssl                = false
+}
+`, name)
+}
+
+func testAccNewRelicSyntheticsMonitorConfigBrowserUpdated(name string) string {
+	return fmt.Sprintf(`
+resource "newrelic_synthetics_monitor" "foo" {
+	name      = "%[1]s-browser-test-updated"
+	type      = "BROWSER"
+	frequency = 5
+	status    = "ENABLED"
+	locations = ["AWS_US_EAST_1", "AWS_US_WEST_1"]
+
+	uri                       = "https://example-updated.com"
+	validation_string         = "this text should exist in the response updated"
+	verify_ssl                = true
 }
 `, name)
 }

--- a/newrelic/resource_newrelic_synthetics_monitor_test.go
+++ b/newrelic/resource_newrelic_synthetics_monitor_test.go
@@ -10,47 +10,38 @@ import (
 )
 
 func TestAccNewRelicSyntheticsMonitor_Basic(t *testing.T) {
+	resourceName := "newrelic_synthetics_monitor.foo"
 	rName := acctest.RandString(5)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicSyntheticsMonitorDestroy,
 		Steps: []resource.TestStep{
+			// Test: Create
 			{
-				Config: testAccCheckNewRelicSyntheticsMonitorConfig(rName),
+				Config: testAccNewRelicSyntheticsMonitorConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicSyntheticsMonitorExists("newrelic_synthetics_monitor.foo"),
-					resource.TestCheckResourceAttr(
-						"newrelic_synthetics_monitor.foo", "name", rName),
-					resource.TestCheckResourceAttr(
-						"newrelic_synthetics_monitor.foo", "type", "SIMPLE"),
-					resource.TestCheckResourceAttr(
-						"newrelic_synthetics_monitor.foo", "frequency", "1"),
-					resource.TestCheckResourceAttr(
-						"newrelic_synthetics_monitor.foo", "status", "DISABLED"),
-					resource.TestCheckResourceAttr(
-						"newrelic_synthetics_monitor.foo", "uri", "https://google.com"),
-					resource.TestCheckResourceAttr(
-						"newrelic_synthetics_monitor.foo", "locations.#", "1"),
+					testAccCheckNewRelicSyntheticsMonitorExists(resourceName),
 				),
 			},
+			// Test: No diff on re-apply
 			{
-				Config: testAccCheckNewRelicSyntheticsMonitorConfigUpdated(rName),
+				Config:             testAccNewRelicSyntheticsMonitorConfig(rName),
+				ExpectNonEmptyPlan: false,
+			},
+			// Test: Update
+			{
+				Config: testAccNewRelicSyntheticsMonitorConfigUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicSyntheticsMonitorExists("newrelic_synthetics_monitor.foo"),
-					resource.TestCheckResourceAttr(
-						"newrelic_synthetics_monitor.foo", "name", fmt.Sprintf("%s-updated", rName)),
-					resource.TestCheckResourceAttr(
-						"newrelic_synthetics_monitor.foo", "type", "SIMPLE"),
-					resource.TestCheckResourceAttr(
-						"newrelic_synthetics_monitor.foo", "frequency", "5"),
-					resource.TestCheckResourceAttr(
-						"newrelic_synthetics_monitor.foo", "status", "ENABLED"),
-					resource.TestCheckResourceAttr(
-						"newrelic_synthetics_monitor.foo", "uri", "https://github.com"),
-					resource.TestCheckResourceAttr(
-						"newrelic_synthetics_monitor.foo", "locations.#", "2"),
+					testAccCheckNewRelicSyntheticsMonitorExists(resourceName),
 				),
+			},
+			// Test: Import
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -97,30 +88,28 @@ func testAccCheckNewRelicSyntheticsMonitorDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckNewRelicSyntheticsMonitorConfig(rName string) string {
+func testAccNewRelicSyntheticsMonitorConfig(name string) string {
 	return fmt.Sprintf(`
-
 resource "newrelic_synthetics_monitor" "foo" {
-  name = "%[1]s"
-  type = "SIMPLE"
-  frequency = 1
-  status = "DISABLED"
-  locations = ["AWS_US_EAST_1"]
-  uri = "https://google.com"
+	name      = "%[1]s"
+	type      = "SIMPLE"
+	frequency = 1
+	status    = "DISABLED"
+	locations = ["AWS_US_EAST_1"]
+	uri       = "https://google.com"
 }
-`, rName)
+`, name)
 }
 
-func testAccCheckNewRelicSyntheticsMonitorConfigUpdated(rName string) string {
+func testAccNewRelicSyntheticsMonitorConfigUpdated(name string) string {
 	return fmt.Sprintf(`
-
 resource "newrelic_synthetics_monitor" "foo" {
-  name = "%[1]s-updated"
-  type = "SIMPLE"
-  frequency = 5
-  status = "ENABLED"
-  locations = ["AWS_US_EAST_1", "AWS_US_WEST_1"]
-  uri = "https://github.com"
+	name      = "%[1]s-updated"
+	type      = "SIMPLE"
+	frequency = 5
+	status    = "ENABLED"
+	locations = ["AWS_US_EAST_1", "AWS_US_WEST_1"]
+	uri       = "https://github.com"
 }
-`, rName)
+`, name)
 }

--- a/newrelic/resource_newrelic_synthetics_monitor_test.go
+++ b/newrelic/resource_newrelic_synthetics_monitor_test.go
@@ -85,6 +85,40 @@ func TestAccNewRelicSyntheticsMonitor_Browser(t *testing.T) {
 	})
 }
 
+func TestAccNewRelicSyntheticsMonitor_ScriptBrowser(t *testing.T) {
+	resourceName := "newrelic_synthetics_monitor.foo"
+	rName := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicSyntheticsMonitorDestroy,
+		Steps: []resource.TestStep{
+			// Test: Create
+			{
+				Config: testAccNewRelicSyntheticsMonitorConfigScriptBrowser(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicSyntheticsMonitorExists(resourceName),
+				),
+			},
+			// Test: No diff on re-apply
+			{
+				Config:             testAccNewRelicSyntheticsMonitorConfigScriptBrowser(rName),
+				ExpectNonEmptyPlan: false,
+			},
+			// TODO: Test: Update
+			// (update needs to be fixed for type SCRIPT_BROWSER and SCRIPT_API)
+
+			// Test: Import
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckNewRelicSyntheticsMonitorExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -190,6 +224,18 @@ resource "newrelic_synthetics_monitor" "foo" {
 	uri                       = "https://example-updated.com"
 	validation_string         = "this text should exist in the response updated"
 	verify_ssl                = true
+}
+`, name)
+}
+
+func testAccNewRelicSyntheticsMonitorConfigScriptBrowser(name string) string {
+	return fmt.Sprintf(`
+resource "newrelic_synthetics_monitor" "foo" {
+	name      = "%[1]s-script-browser-test"
+	type      = "SCRIPT_BROWSER"
+	frequency = 1
+	status    = "DISABLED"
+	locations = ["AWS_US_EAST_1"]
 }
 `, name)
 }

--- a/website/docs/r/synthetics_monitor.html.markdown
+++ b/website/docs/r/synthetics_monitor.html.markdown
@@ -12,28 +12,34 @@ Use this resource to create, update, and delete a synthetics monitor in New Reli
 
 ## Example Usage
 
+##### Type: `SIMPLE`
 ```hcl
 resource "newrelic_synthetics_monitor" "foo" {
   name = "foo"
   type = "SIMPLE"
   frequency = 5
   status = "ENABLED"
-  locations = ["AWS_US_EAST_1"]
+  locations = ["AWS_US_EAST_1", "AWS_US_EAST_2"]
+
+  uri                       = "https://example.com"               # Required for type "SIMPLE" and "BROWSER"
+  validation_string         = "add example validation check here" # Optional for type "SIMPLE" and "BROWSER"
+  verify_ssl                = true                                # Optional for type "SIMPLE" and "BROWSER"
 }
 ```
+See additional [examples](#additional-examples).
 
 ## Argument Reference
 
 The following arguments are supported:
 
   * `name` - (Required) The title of this monitor.
-  * `type` - (Required) The monitor type (i.e. SIMPLE, BROWSER, SCRIPT_API, SCRIPT_BROWSER).
+  * `type` - (Required) The monitor type. Valid values are `SIMPLE`, `BROWSER`, `SCRIPT_BROWSER`, and `SCRIPT_API`.
   * `frequency` - (Required) The interval (in minutes) at which this monitor should run.
-  * `status` - (Required) The monitor status (i.e. ENABLED, MUTED, DISABLED)
+  * `status` - (Required) The monitor status (i.e. `ENABLED`, `MUTED`, `DISABLED`)
   * `locations` - (Required) The locations in which this monitor should be run.
   * `sla_threshold` - (Optional) The base threshold for the SLA report.
-  
-For SIMPLE and BROWSER monitor types, the following arguments are also supported:
+
+ The `SIMPLE` monitor type supports the following additional arguments:
 
   * `uri` - (Required) The URI for the monitor to hit.
   * `validation_string` - (Optional) The string to validate against in the response.
@@ -41,8 +47,58 @@ For SIMPLE and BROWSER monitor types, the following arguments are also supported
   * `bypass_head_request` - (Optional) Bypass HEAD request.
   * `treat_redirect_as_failure` - (Optional) Fail the monitor check if redirected.
 
+The `BROWSER` monitor type supports the following additional arguments:
+
+  * `uri` - (Required) The URI for the monitor to hit.
+  * `validation_string` - (Optional) The string to validate against in the response.
+  * `verify_ssl` - (Optional) Verify SSL.
+
 ## Attributes Reference
 
 The following attributes are exported:
 
   * `id` - The ID of the Synthetics monitor.
+
+## Additional Examples
+
+Type: `BROWSER`
+
+```hcl
+resource "newrelic_synthetics_monitor" "foo" {
+  name = "foo"
+  type = "BROWSER"
+  frequency = 5
+  status = "ENABLED"
+  locations = ["AWS_US_EAST_1"]
+
+  uri                       = "https://example.com"               # required for type "SIMPLE" and "BROWSER"
+  validation_string         = "add example validation check here" # optional for type "SIMPLE" and "BROWSER"
+  verify_ssl                = true                                # optional for type "SIMPLE" and "BROWSER"
+  bypass_head_request       = true                                # Note: optional for type "BROWSER" only
+  treat_redirect_as_failure = true                                # Note: optional for type "BROWSER" only
+}
+```
+
+Type: `SCRIPT_BROWSER`
+
+```hcl
+resource "newrelic_synthetics_monitor" "foo" {
+  name = "foo"
+  type = "SCRIPT_BROWSER"
+  frequency = 5
+  status = "ENABLED"
+  locations = ["AWS_US_EAST_1"]
+}
+```
+
+Type: `SCRIPT_API`
+
+```hcl
+resource "newrelic_synthetics_monitor" "foo" {
+  name = "foo"
+  type = "SCRIPT_API"
+  frequency = 5
+  status = "ENABLED"
+  locations = ["AWS_US_EAST_1"]
+}
+```


### PR DESCRIPTION
Resolves: #222 

IMPROVEMENTS:
- update `newrelic_synthetics_monitor` acceptance tests to use our design pattern
- add additional test coverage for `newrelic_synthetics_monitor`
- add `import` test for `newrelic_synthetics_monitor`

<sup>Note: Attempting to update type `SCRIPT_BROWSER` and `SCRIPT_API` will cause an error due to how the `dollarshaveclub/new-relic-synthetics-go` client handles the update in [these lines of code](https://github.com/dollarshaveclub/new-relic-synthetics-go/blob/master/synthetics.go#L397-L408). The `options` should be set conditionally based on the type of monitor.</sup>