### PR TITLE
test: backfill acceptance tests for key transactions data source

### DIFF
--- a/newrelic/data_source_newrelic_key_transaction_test.go
+++ b/newrelic/data_source_newrelic_key_transaction_test.go
@@ -1,0 +1,61 @@
+package newrelic
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+var (
+	testAccExpectedKeyTransactionName string = "get /"
+)
+
+func TestAccNewRelicKeyTransactionDataSource_Basic(t *testing.T) {
+	if !nrInternalAccount {
+		t.Skipf("New Relic internal testing account required")
+	}
+
+	resourceName := "data.newrelic_key_transaction.foo"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNewRelicKeyTransactionDataSourceConfig(testAccExpectedKeyTransactionName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicKeyTransactionDataSourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", testAccExpectedKeyTransactionName),
+				),
+			},
+		},
+	})
+}
+
+func testAccNewRelicKeyTransactionDataSourceConfig(rName string) string {
+	return fmt.Sprintf(`
+data "newrelic_key_transaction" "foo" {
+	name = "%s"
+}
+`, testAccExpectedKeyTransactionName)
+}
+
+func testAccCheckNewRelicKeyTransactionDataSourceExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		if a["id"] == "" {
+			return fmt.Errorf("expected to get a key transaction from New Relic")
+		}
+
+		if !strings.EqualFold(testAccExpectedKeyTransactionName, a["name"]) {
+			return fmt.Errorf("expected the key transaction name to be: %s, but got: %s", testAccExpectedKeyTransactionName, a["name"])
+		}
+
+		return nil
+	}
+}

--- a/website/docs/d/alert_channel.html.markdown
+++ b/website/docs/d/alert_channel.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # newrelic\_alert\_channel
 
-Use this data source to get information about a specific alert channel in New Relic that already exists (e.g newrelic user). More information on Terraform's data sources can be found [here](https://www.terraform.io/docs/configuration/data-sources.html).
+Use this data source to get information about a specific alert channel in New Relic that already exists.  More information on Terraform's data sources can be found [here](https://www.terraform.io/docs/configuration/data-sources.html).
 
 ## Example Usage
 

--- a/website/docs/d/alert_policy.html.markdown
+++ b/website/docs/d/alert_policy.html.markdown
@@ -8,7 +8,8 @@ description: |-
 
 # newrelic\_alert\_policy
 
-Use this data source to get information about an specific alert policy in New Relic which already exists.
+Use this data source to get information about a specific alert policy in New Relic that already exists.
+More information on Terraform's data sources can be found [here](https://www.terraform.io/docs/configuration/data-sources.html).
 
 ## Example Usage
 

--- a/website/docs/d/application.html.markdown
+++ b/website/docs/d/application.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # newrelic\_application
 
-Use this data source to get information about a specific application in New Relic.
+Use this data source to get information about a specific application in New Relic that already exists. More information on Terraform's data sources can be found [here](https://www.terraform.io/docs/configuration/data-sources.html).
 
 ## Example Usage
 

--- a/website/docs/d/key_transaction.html.markdown
+++ b/website/docs/d/key_transaction.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # newrelic\_key\_transaction
 
-Use this data source to get information about a specific key transaction in New Relic.
+Use this data source to get information about a specific key transaction in New Relic that already exists.  More information on Terraform's data sources can be found [here](https://www.terraform.io/docs/configuration/data-sources.html).
 
 ## Example Usage
 

--- a/website/docs/d/plugin.html.markdown
+++ b/website/docs/d/plugin.html.markdown
@@ -8,9 +8,9 @@ description: |-
 
 # newrelic\_plugin
 
-Use this data source to get information about a specific installed plugin in New Relic.
+Use this data source to get information about a specific installed plugin in New Relic. More information on Terraform's data sources can be found [here](https://www.terraform.io/docs/configuration/data-sources.html).
 
-Each plugin published to New Relic's Plugin Central is assigned a [GUID](https://docs.newrelic.com/docs/plugins/plugin-developer-resources/planning-your-plugin/parts-plugin#guid). Once you have installed a plugin into your account it is assigned an ID. This account-specific ID is required when creating Plugins Alert Conditions.
+Each plugin published to New Relic's Plugin Central is assigned a [GUID](https://docs.newrelic.com/docs/plugins/plugin-developer-resources/planning-your-plugin/parts-plugin#guid). Once you have installed a plugin into your account it is assigned an ID. This account-specific ID is required when creating Plugins alert conditions.
 
 ## Example Usage
 

--- a/website/docs/d/plugin_component.html.markdown
+++ b/website/docs/d/plugin_component.html.markdown
@@ -8,9 +8,10 @@ description: |-
 
 # newrelic\_plugin\_component
 
-Use this data source to get information about a single plugin component in New Relic.
+Use this data source to get information about a single plugin component in New Relic that already exists.
+More information on Terraform's data sources can be found [here](https://www.terraform.io/docs/configuration/data-sources.html).
 
-Each plugin component reporting into to New Relic is assigned a unique ID. Once you have a plugin component reporting data into your account, its component ID can be used to create Plugins Alert Conditions.
+Each plugin component reporting into to New Relic is assigned a unique ID. Once you have a plugin component reporting data into your account, its component ID can be used to create Plugins alert conditions.
 
 ## Example Usage
 

--- a/website/docs/d/synthetics_monitor.html.markdown
+++ b/website/docs/d/synthetics_monitor.html.markdown
@@ -1,14 +1,14 @@
 ---
 layout: "newrelic"
 page_title: "New Relic: newrelic_synthetics_monitor"
-sidebar_current: "docs-newrelic-synthetics-monitor"
+sidebar_current: "docs-newrelic-datasource-synthetics-monitor"
 description: |-
   Grabs a synthetics monitor by name.
 ---
 
 # newrelic\_synthetics\_monitor
 
-Use this data source to get information about a specific synthetics monitor in New Relic. This can then be used to set up a synthetics alert condition.
+Use this data source to get information about a specific synthetics monitor in New Relic that already exists. This can be used to set up a Synthetics alert condition.
 
 ## Example Usage
 

--- a/website/docs/r/alert_channel.html.markdown
+++ b/website/docs/r/alert_channel.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 # newrelic\_alert\_channel
 
+Use this resource to create and manage New Relic alert policies.
+
 ## Example Usage
 
 ##### Email

--- a/website/docs/r/alert_condition.html.markdown
+++ b/website/docs/r/alert_condition.html.markdown
@@ -3,10 +3,12 @@ layout: "newrelic"
 page_title: "New Relic: newrelic_alert_condition"
 sidebar_current: "docs-newrelic-resource-alert-condition"
 description: |-
-  Create and manage an alert condition for a policy in New Relic.
+  Create and manage alert conditions for APM, Browser, and Mobile in New Relic.
 ---
 
 # newrelic\_alert\_condition
+
+Use this resource to create and manage alert conditions for APM, Browser, and Mobile in New Relic.
 
 ## Example Usage
 

--- a/website/docs/r/alert_policy.html.markdown
+++ b/website/docs/r/alert_policy.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 # newrelic\_alert\_policy
 
+Use this resource to create and manage New Relic alert policies.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/alert_policy_channel.html.markdown
+++ b/website/docs/r/alert_policy_channel.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 # newrelic\_alert\_policy\_channel
 
+Use this resource to map alert policies to alert channels in New Relic.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/dashboard.html.markdown
+++ b/website/docs/r/dashboard.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # newrelic\_dashboard
 
-This resource can be used to create and manage New Relic dashboards.
+Use this resource to create and manage New Relic dashboards.
 
 ## Example Usage: Create a New Relic Dashboard
 

--- a/website/docs/r/infra_alert_condition.html.markdown
+++ b/website/docs/r/infra_alert_condition.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 # newrelic\_infra_alert\_condition
 
+Use this resource to create and manage Infrastructure alert conditions in New Relic.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 # newrelic_nrql_alert_condition
 
+Use this resource to create and manage NRQL alert conditions in New Relic.
+
 ## Example Usage
 
 ##### Type: `static` (default)

--- a/website/docs/r/plugins_alert_condition.html.markdown
+++ b/website/docs/r/plugins_alert_condition.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 # newrelic\_plugins\_alert\_condition
 
+Use this resource to create and manage plugins alert conditions in New Relic.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/synthetics_alert_condition.html.markdown
+++ b/website/docs/r/synthetics_alert_condition.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 # newrelic\_synthetics\_alert\_condition
 
+Use this resource to create and manage synthetics alert conditions in New Relic.
+
 ## Example Usage
 
 ```hcl

--- a/website/newrelic.erb
+++ b/website/newrelic.erb
@@ -21,17 +21,17 @@
                 <li<%= sidebar_current("docs-newrelic-datasource-alert-channel") %>>
                     <a href="/docs/providers/newrelic/d/alert_channel.html">newrelic_alert_channel</a>
                 </li>
+                <li<%= sidebar_current("docs-newrelic-datasource-alert-policy") %>>
+                    <a href="/docs/providers/newrelic/d/alert_policy.html">newrelic_alert_policy</a>
+                </li>
                 <li<%= sidebar_current("docs-newrelic-datasource-application") %>>
                     <a href="/docs/providers/newrelic/d/application.html">newrelic_application</a>
                 </li>
                 <li<%= sidebar_current("docs-newrelic-datasource-key-transaction") %>>
-                    <a href="/docs/providers/newrelic/d/key_transaction.html">key_transaction</a>
+                    <a href="/docs/providers/newrelic/d/key_transaction.html">newrelic_key_transaction</a>
                 </li>
                 <li<%= sidebar_current("docs-newrelic-datasource-synthetics-monitor") %>>
-                    <a href="/docs/providers/newrelic/d/synthetics_monitor.html">synthetics_monitor</a>
-                </li>
-                <li<%= sidebar_current("docs-newrelic-datasource-alert-policy") %>>
-                    <a href="/docs/providers/newrelic/d/alert_policy.html">newrelic_alert_policy</a>
+                    <a href="/docs/providers/newrelic/d/synthetics_monitor.html">newrelic_synthetics_monitor</a>
                 </li>
             </ul>
         </li>
@@ -51,26 +51,26 @@
                 <li<%= sidebar_current("docs-newrelic-resource-alert-policy-channel") %>>
                     <a href="/docs/providers/newrelic/r/alert_policy_channel.html">newrelic_alert_policy_channel</a>
                 </li>
+                <li<%= sidebar_current("docs-newrelic-resource-dashboard") %>>
+                    <a href="/docs/providers/newrelic/r/dashboard.html">newrelic_dashboard</a>
+                </li>
+                <li<%= sidebar_current("docs-newrelic-resource-infra-alert-condition") %>>
+                    <a href="/docs/providers/newrelic/r/infra_alert_condition.html">newrelic_infra_alert_condition</a>
+                </li>
                 <li<%= sidebar_current("docs-newrelic-resource-insights-event") %>>
                     <a href="/docs/providers/newrelic/r/insights_event.html">newrelic_insights_event</a>
                 </li>
                 <li<%= sidebar_current("docs-newrelic-resource-nrql-alert-condition") %>>
                     <a href="/docs/providers/newrelic/r/nrql_alert_condition.html">newrelic_nrql_alert_condition</a>
                 </li>
-                <li<%= sidebar_current("docs-newrelic-resource-infra-alert-condition") %>>
-                    <a href="/docs/providers/newrelic/r/infra_alert_condition.html">newrelic_infra_alert_condition</a>
-                </li>
-                <li<%= sidebar_current("docs-newrelic-synthetics-alert-condition") %>>
+                <li<%= sidebar_current("docs-newrelic-resource-synthetics-alert-condition") %>>
                     <a href="/docs/providers/newrelic/r/synthetics_alert_condition.html">newrelic_synthetics_alert_condition</a>
                 </li>
-                <li<%= sidebar_current("docs-newrelic-synthetics-monitor") %>>
+                <li<%= sidebar_current("docs-newrelic-resource-synthetics-monitor") %>>
                     <a href="/docs/providers/newrelic/r/synthetics_monitor.html">newrelic_synthetics_monitor</a>
                 </li>
-                <li<%= sidebar_current("docs-newrelic-synthetics-monitor_script") %>>
+                <li<%= sidebar_current("docs-newrelic-resource-synthetics-monitor_script") %>>
                     <a href="/docs/providers/newrelic/r/synthetics_monitor_script.html">newrelic_synthetics_monitor_script</a>
-                </li>
-                <li<%= sidebar_current("docs-newrelic-resource-dashboard") %>>
-                    <a href="/docs/providers/newrelic/r/dashboard.html">newrelic_dashboard</a>
                 </li>
             </ul>
         </li>


### PR DESCRIPTION
Resolves #218 .

This PR backfills acceptance testing for the key transactions data source.  This test has been restricted to the NR internal testing account since the key transaction is required to be preconfigured in that account.
  
It also removes an import test from the alert policy data source and updates various portions of the documentation site for consistency.

