### PR TITLE
fix: use name as filter in application lookup

### DIFF
--- a/newrelic/data_source_newrelic_application.go
+++ b/newrelic/data_source_newrelic_application.go
@@ -36,13 +36,14 @@ func dataSourceNewRelicApplicationRead(d *schema.ResourceData, meta interface{})
 
 	log.Printf("[INFO] Reading New Relic applications")
 
-	applications, err := client.ListApplications()
+	name := d.Get("name").(string)
+	filter := newrelic.ApplicationsFilters{Name: &name}
+	applications, err := client.QueryApplications(filter)
 	if err != nil {
 		return err
 	}
 
 	var application *newrelic.Application
-	name := d.Get("name").(string)
 
 	for _, a := range applications {
 		if a.Name == name {


### PR DESCRIPTION
Resolves #176 .

This PR passes the `newrelic_application` data source's `name` attribute as a filter to the underlying API endpoint when refreshing the state.  This greatly reduces the amount of paging required for lookups in cases where an account has many applications.