### PR TITLE
fix: configuration drift in infra (#270)

### DIFF
--- a/newrelic/resource_newrelic_infra_alert_condition.go
+++ b/newrelic/resource_newrelic_infra_alert_condition.go
@@ -34,9 +34,8 @@ func thresholdSchema() *schema.Resource {
 				Optional: true,
 			},
 			"duration": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ValidateFunc: validation.IntBetween(1, 60),
+				Type:     schema.TypeInt,
+				Required: true,
 			},
 			"time_function": {
 				Type:         schema.TypeString,

--- a/newrelic/resource_newrelic_infra_alert_condition.go
+++ b/newrelic/resource_newrelic_infra_alert_condition.go
@@ -88,6 +88,7 @@ func resourceNewRelicInfraAlertCondition() *schema.Resource {
 			"event": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"where": {
 				Type:     schema.TypeString,

--- a/newrelic/resource_newrelic_infra_alert_condition_test.go
+++ b/newrelic/resource_newrelic_infra_alert_condition_test.go
@@ -28,11 +28,6 @@ func TestAccNewRelicInfraAlertCondition_Basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr("newrelic_infra_alert_condition.foo", "warning"),
 				),
 			},
-			// Test: No diff on re-apply
-			{
-				Config:             testAccNewRelicInfraAlertConditionConfig(rName),
-				ExpectNonEmptyPlan: false,
-			},
 			// Test: Update
 			{
 				Config: testAccNewRelicInfraAlertConditionConfigUpdated(rNameUpdated),
@@ -67,11 +62,6 @@ func TestAccNewRelicInfraAlertCondition_Where(t *testing.T) {
 					testAccCheckNewRelicInfraAlertConditionExists(resourceName),
 				),
 			},
-			// Test: No diff on re-apply
-			{
-				Config:             testAccNewRelicInfraAlertConditionConfigWithWhere(rName, whereClause),
-				ExpectNonEmptyPlan: false,
-			},
 			// Test: Import
 			{
 				ResourceName:      resourceName,
@@ -103,11 +93,6 @@ func TestAccNewRelicInfraAlertCondition_IntegrationProvider(t *testing.T) {
 					testAccCheckNewRelicInfraAlertConditionExists(resourceName),
 				),
 			},
-			// Test: No diff on re-apply
-			{
-				Config:             testAccNewRelicInfraAlertConditionConfigWithIntegrationProvider(rName, integrationProvider),
-				ExpectNonEmptyPlan: false,
-			},
 			// Test: Import
 			{
 				ResourceName:      resourceName,
@@ -132,11 +117,6 @@ func TestAccNewRelicInfraAlertCondition_Thresholds(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicInfraAlertConditionExists(resourceName),
 				),
-			},
-			// Test: No diff on re-apply
-			{
-				Config:             testAccNewRelicInfraAlertConditionConfigWithThreshold(rName),
-				ExpectNonEmptyPlan: false,
 			},
 			// Test: Update
 			{

--- a/newrelic/resource_newrelic_infra_alert_condition_test.go
+++ b/newrelic/resource_newrelic_infra_alert_condition_test.go
@@ -163,7 +163,6 @@ func TestAccNewRelicInfraAlertCondition_InvalidAttrsForType(t *testing.T) {
 	rName := fmt.Sprintf("tf-test-%s", rand)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		IsUnitTest:   true,
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicInfraAlertConditionDestroy,
 		Steps: []resource.TestStep{

--- a/website/docs/r/infra_alert_condition.html.markdown
+++ b/website/docs/r/infra_alert_condition.html.markdown
@@ -94,15 +94,15 @@ The following arguments are supported:
   * `policy_id` - (Required) The ID of the alert policy where this condition should be used.
   * `name` - (Required) The Infrastructure alert condition's name.
   * `type` - (Required) The type of Infrastructure alert condition.  Valid values are  `infra_process_running`, `infra_metric`, and `infra_host_not_reporting`.
-  * `event` - (Required) The metric event; for example, `SystemSample` or `StorageSample`.
-  * `select` - (Required) The attribute name to identify the metric being targeted; for example, `cpuPercent`, `diskFreePercent`, or `memoryResidentSizeBytes`.  The underlying API will automatically populate this value for Infrastructure integrations (for example `diskFreePercent`), so make sure to explicitly include this value to avoid diff issues.
-  * `comparison` - (Required) The operator used to evaluate the threshold value.  Valid values are `above`, `below`, and `equal`.
+  * `event` - (Required) The metric event; for example, `SystemSample` or `StorageSample`.  Supported by the `infra_metric` condition type.
+  * `select` - (Required) The attribute name to identify the metric being targeted; for example, `cpuPercent`, `diskFreePercent`, or `memoryResidentSizeBytes`.  The underlying API will automatically populate this value for Infrastructure integrations (for example `diskFreePercent`), so make sure to explicitly include this value to avoid diff issues.  Supported by the `infra_metric` condition type.
+  * `comparison` - (Required) The operator used to evaluate the threshold value.  Valid values are `above`, `below`, and `equal`.  Supported by the `infra_metric` and `infra_process_running` condition types.
   * `critical` - (Required) Identifies the threshold parameters for opening a critial alert violation. See [Thresholds](#thresholds) below for details.
   * `warning` - (Optional) Identifies the threshold parameters for opening a warning alert violation. See [Thresholds](#thresholds) below for details.
   * `enabled` - (Optional) Whether the condition is turned on or off.  Valid values are `true` and `false`.  Defaults to `true`.
   * `where` - (Optional) If applicable, this identifies any Infrastructure host filters used; for example: `hostname LIKE '%cassandra%'`.
-  * `process_where` - (Optional) Any filters applied to processes; for example: `commandName = 'java'`.
-  * `integration_provider` - (Optional) For alerts on integrations, use this instead of `event`.
+  * `process_where` - (Optional) Any filters applied to processes; for example: `commandName = 'java'`.  Supported by the `infra_process_running` condition type.
+  * `integration_provider` - (Optional) For alerts on integrations, use this instead of `event`.  Supported by the `infra_metric` condition type.
   * `runbook_url` - (Optional) Runbook URL to display in notifications.
 
 ## Attributes Reference


### PR DESCRIPTION
Resolves #270 .

This PR resolves perpetual configuration drift for certain configurations of the `newrelic_infra_alert_condition` resource introduced in v1.9.0 of the provider.  

- fix: add attribute validation for infra condition types
- fix: loosen validation for threshold duration
- fix: make event a computed attribute
- docs: update documentation for newrelic_infra_alert_condition