### PR TITLE
docs/test: remove usage of deprecated HCL & doc updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,13 @@
 ## 1.10.0 (Unreleased)
 
 IMPROVEMENTS:
-feat: add ability to import `newrelic_synthetics_monitor` ([#267](https://github.com/terraform-providers/terraform-provider-newrelic/pull/267))
-docs: multiple improvements for readability and consistency
+* feat: add ability to import `newrelic_synthetics_monitor` ([#267](https://github.com/terraform-providers/terraform-provider-newrelic/pull/267))
+* docs: multiple improvements for readability and consistency
 
 BUG FIXES:
-fix: add attribute validation for infra condition types ([#277](https://github.com/terraform-providers/terraform-provider-newrelic/pull/277))
-fix: loosen validation for threshold duration ([#277](https://github.com/terraform-providers/terraform-provider-newrelic/pull/277))
-fix: make event a computed attribute ([#277](https://github.com/terraform-providers/terraform-provider-newrelic/pull/277))
-
+* fix: add attribute validation for infra condition types ([#277](https://github.com/terraform-providers/terraform-provider-newrelic/pull/277))
+* fix: loosen validation for threshold duration ([#277](https://github.com/terraform-providers/terraform-provider-newrelic/pull/277))
+* fix: make event a computed attribute ([#277](https://github.com/terraform-providers/terraform-provider-newrelic/pull/277))
 
 ## 1.9.0 (December 05, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-## 1.9.1 (Unreleased)
+## 1.10.0 (Unreleased)
+
+IMPROVEMENTS:
+feat: add ability to import `newrelic_synthetics_monitor` ([#267](https://github.com/terraform-providers/terraform-provider-newrelic/pull/267))
+docs: multiple improvements for readability and consistency
+
+BUG FIXES:
+fix: add attribute validation for infra condition types ([#277](https://github.com/terraform-providers/terraform-provider-newrelic/pull/277))
+fix: loosen validation for threshold duration ([#277](https://github.com/terraform-providers/terraform-provider-newrelic/pull/277))
+fix: make event a computed attribute ([#277](https://github.com/terraform-providers/terraform-provider-newrelic/pull/277))
+
+
 ## 1.9.0 (December 05, 2019)
 
 IMPROVEMENTS:

--- a/newrelic/data_source_newrelic_alert_channel_test.go
+++ b/newrelic/data_source_newrelic_alert_channel_test.go
@@ -59,7 +59,7 @@ resource "newrelic_alert_channel" "foo" {
 }
 
 data "newrelic_alert_channel" "channel" {
-	name = "${newrelic_alert_channel.foo.name}"
+	name = newrelic_alert_channel.foo.name
 }
 `, name)
 }

--- a/newrelic/data_source_newrelic_alert_policy_test.go
+++ b/newrelic/data_source_newrelic_alert_policy_test.go
@@ -52,7 +52,7 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 data "newrelic_alert_policy" "policy" {
-	name = "${newrelic_alert_policy.foo.name}"
+	name = newrelic_alert_policy.foo.name
 }
 `, name)
 }

--- a/newrelic/data_source_newrelic_plugin_component_test.go
+++ b/newrelic/data_source_newrelic_plugin_component_test.go
@@ -46,7 +46,7 @@ data "newrelic_plugin" "foo" {
 	guid = "net.kenjij.newrelic_redis_plugin"
 }
 data "newrelic_plugin_component" "foo" {
-	plugin_id = "${data.newrelic_plugin.foo.id}"
+	plugin_id = data.newrelic_plugin.foo.id
 	name = "MyRedisServer"
 }
 `

--- a/newrelic/data_source_newrelic_synthetics_monitor_test.go
+++ b/newrelic/data_source_newrelic_synthetics_monitor_test.go
@@ -57,7 +57,7 @@ resource "newrelic_synthetics_monitor" "foo" {
 }
 
 data "newrelic_synthetics_monitor" "bar" {
-	name = "${newrelic_synthetics_monitor.foo.name}"
+	name = newrelic_synthetics_monitor.foo.name
 }
 `, name)
 }

--- a/newrelic/resource_newrelic_alert_condition_test.go
+++ b/newrelic/resource_newrelic_alert_condition_test.go
@@ -269,12 +269,12 @@ resource "newrelic_alert_policy" "foo" {
 	name = "%[1]s"
 }
 resource "newrelic_alert_condition" "foo" {
-	policy_id = "${newrelic_alert_policy.foo.id}"
+	policy_id = newrelic_alert_policy.foo.id
 
 	name            = "%[1]s"
 	enabled         = true
 	type            = "apm_app_metric"
-	entities        = ["${data.newrelic_application.app.id}"]
+	entities        = [data.newrelic_application.app.id]
 	metric          = "apdex"
 	runbook_url     = "https://foo.example.com"
 	condition_scope = "application"
@@ -299,12 +299,12 @@ resource "newrelic_alert_policy" "foo" {
 	name = "%[1]s"
 }
 resource "newrelic_alert_condition" "foo" {
-	policy_id = "${newrelic_alert_policy.foo.id}"
+	policy_id = newrelic_alert_policy.foo.id
 
 	name            = "%[1]s"
 	enabled         = false
 	type            = "apm_app_metric"
-	entities        = ["${data.newrelic_application.app.id}"]
+	entities        = [data.newrelic_application.app.id]
 	metric          = "error_percentage"
 	runbook_url     = "https://bar.example.com"
 	condition_scope = "application"
@@ -329,12 +329,12 @@ resource "newrelic_alert_policy" "foo" {
 	name = "%[1]s"
 }
 resource "newrelic_alert_condition" "foo" {
-	policy_id = "${newrelic_alert_policy.foo.id}"
+	policy_id = newrelic_alert_policy.foo.id
 
 	name            = "%[1]s"
 	enabled         = false
 	type            = "apm_app_metric"
-	entities        = ["${data.newrelic_application.app.id}"]
+	entities        = [data.newrelic_application.app.id]
 	metric          = "apdex"
 	runbook_url     = "https://foo.example.com"
 	condition_scope = "application"
@@ -359,7 +359,7 @@ resource "newrelic_alert_policy" "foo" {
 	name = "%[1]s"
 }
 resource "newrelic_alert_condition" "foo" {
-	policy_id = "${newrelic_alert_policy.foo.id}"
+	policy_id = newrelic_alert_policy.foo.id
 	name            = "test-term-duration"
 	type            = "apm_app_metric"
 	entities        = ["12345"]

--- a/newrelic/resource_newrelic_alert_policy_channel_test.go
+++ b/newrelic/resource_newrelic_alert_policy_channel_test.go
@@ -166,8 +166,8 @@ resource "newrelic_alert_channel" "foo" {
 }
 
 resource "newrelic_alert_policy_channel" "foo" {
-  policy_id  = "${newrelic_alert_policy.foo.id}"
-  channel_id = "${newrelic_alert_channel.foo.id}"
+  policy_id  = newrelic_alert_policy.foo.id
+  channel_id = newrelic_alert_channel.foo.id
 }
 `, name)
 }
@@ -189,8 +189,8 @@ resource "newrelic_alert_channel" "foo" {
 }
 
 resource "newrelic_alert_policy_channel" "foo" {
-  policy_id  = "${newrelic_alert_policy.foo.id}"
-  channel_id = "${newrelic_alert_channel.foo.id}"
+  policy_id  = newrelic_alert_policy.foo.id
+  channel_id = newrelic_alert_channel.foo.id
 }
 `, rName)
 }

--- a/newrelic/resource_newrelic_infra_alert_condition_test.go
+++ b/newrelic/resource_newrelic_infra_alert_condition_test.go
@@ -262,7 +262,7 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_infra_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+  policy_id = newrelic_alert_policy.foo.id
 
   name            = "%[1]s"
   runbook_url     = "https://foo.example.com"
@@ -287,7 +287,7 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_infra_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+  policy_id = newrelic_alert_policy.foo.id
 
   name            = "%[1]s"
   runbook_url     = "https://bar.example.com"
@@ -312,7 +312,7 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_infra_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+  policy_id = newrelic_alert_policy.foo.id
 
   name            = "%[1]s"
   type            = "infra_metric"
@@ -342,7 +342,7 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_infra_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+  policy_id = newrelic_alert_policy.foo.id
 
   name            = "%[1]s"
   type            = "infra_metric"
@@ -366,7 +366,7 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_infra_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+  policy_id = newrelic_alert_policy.foo.id
 
   name          = "%[1]s"
   type          = "infra_process_running"
@@ -389,7 +389,7 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_infra_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+  policy_id = newrelic_alert_policy.foo.id
 
   name                 = "%[1]s"
   type                 = "infra_metric"
@@ -415,7 +415,7 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_infra_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+  policy_id = newrelic_alert_policy.foo.id
 
   name            = "%[1]s"
   runbook_url     = "https://foo.example.com"
@@ -440,7 +440,7 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_infra_alert_condition" "foo" {
-	policy_id = "${newrelic_alert_policy.foo.id}"
+	policy_id = newrelic_alert_policy.foo.id
 	name                 = "%[1]s"
 	type                 = "infra_metric"
 	integration_provider = "S3Bucket"

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -162,7 +162,7 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_nrql_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+  policy_id = newrelic_alert_policy.foo.id
 
   name            = "tf-test-%[1]s"
   runbook_url     = "https://foo.example.com"
@@ -195,7 +195,7 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_nrql_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+  policy_id = newrelic_alert_policy.foo.id
 
   name            = "tf-test-updated-%[1]s"
   runbook_url     = "https://bar.example.com"
@@ -225,7 +225,7 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_nrql_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+  policy_id = newrelic_alert_policy.foo.id
 
   name            = "tf-test-updated-%[1]s"
   runbook_url     = "https://bar.example.com"

--- a/newrelic/resource_newrelic_plugins_alert_condition_test.go
+++ b/newrelic/resource_newrelic_plugins_alert_condition_test.go
@@ -208,18 +208,18 @@ data "newrelic_plugin" "foo" {
 	guid = "net.kenjij.newrelic_redis_plugin"
 }
 data "newrelic_plugin_component" "foo" {
-	plugin_id = "${data.newrelic_plugin.foo.id}"
+	plugin_id = data.newrelic_plugin.foo.id
 	name = "MyRedisServer"
 }
 resource "newrelic_alert_policy" "foo" {
 	name = "tf-test-%[1]s"
 }
 resource "newrelic_plugins_alert_condition" "foo" {
-	policy_id = "${newrelic_alert_policy.foo.id}"
+	policy_id = newrelic_alert_policy.foo.id
 
 	name               = "tf-test-%[1]s"
 	enabled            = false
-	entities           = ["${data.newrelic_plugin_component.foo.id}"]
+	entities           = [data.newrelic_plugin_component.foo.id]
 	metric             = "Component/Connection/Clients[connections]"
 	runbook_url        = "https://foo.example.com"
 	metric_description = "my-metric-description"
@@ -247,23 +247,23 @@ data "newrelic_plugin" "foo" {
 	guid = "net.kenjij.newrelic_redis_plugin"
 }
 data "newrelic_plugin_component" "foo" {
-	plugin_id = "${data.newrelic_plugin.foo.id}"
+	plugin_id = data.newrelic_plugin.foo.id
 	name = "MyRedisServer"
 }
 resource "newrelic_alert_policy" "foo" {
 	name = "tf-test-updated-%[1]s"
 }
 resource "newrelic_plugins_alert_condition" "foo" {
-	policy_id = "${newrelic_alert_policy.foo.id}"
+	policy_id = newrelic_alert_policy.foo.id
 
 	name               = "tf-test-updated-%[1]s"
 	enabled            = true
-	entities           = ["${data.newrelic_plugin_component.foo.id}"]
+	entities           = [data.newrelic_plugin_component.foo.id]
 	runbook_url        = "https://bar.example.com"
 	metric             = "Component/Connection/Clients[connections]"
 	metric_description = "my-metric-description"
-	plugin_id          = "${data.newrelic_plugin.foo.id}"
-	plugin_guid        = "${data.newrelic_plugin.foo.guid}"
+	plugin_id          = data.newrelic_plugin.foo.id
+	plugin_guid        = data.newrelic_plugin.foo.guid
 	value_function     = "average"
 
 	term {
@@ -286,23 +286,23 @@ data "newrelic_plugin" "foo" {
   guid = "net.kenjij.newrelic_redis_plugin"
 }
 data "newrelic_plugin_component" "foo" {
-	plugin_id = "${data.newrelic_plugin.foo.id}"
+	plugin_id = data.newrelic_plugin.foo.id
 	name = "MyRedisServer"
 }
 resource "newrelic_alert_policy" "foo" {
   name = "tf-test-%[1]s"
 }
 resource "newrelic_plugins_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+  policy_id = newrelic_alert_policy.foo.id
 
   name               = "really-long-name-that-is-more-than-sixtyfour-characters-long-tf-test-%[1]s"
   enabled            = false
-  entities           = ["${data.newrelic_plugin_component.foo.id}"]
+  entities           = [data.newrelic_plugin_component.foo.id]
   runbook_url        = "https://foo.example.com"
   metric             = "Component/Connection/Clients[connections]"
   metric_description = "my-metric-description"
-  plugin_id          = "${data.newrelic_plugin.foo.id}"
-  plugin_guid        = "${data.newrelic_plugin.foo.guid}"
+  plugin_id          = data.newrelic_plugin.foo.id
+  plugin_guid        = data.newrelic_plugin.foo.guid
   value_function     = "average"
 
   term {
@@ -340,23 +340,23 @@ data "newrelic_plugin" "foo" {
 	guid = "net.kenjij.newrelic_redis_plugin"
 }
 data "newrelic_plugin_component" "foo" {
-	plugin_id = "${data.newrelic_plugin.foo.id}"
+	plugin_id = data.newrelic_plugin.foo.id
 	name = "MyRedisServer"
 }
 resource "newrelic_alert_policy" "foo" {
 	name = "tf-test-%[1]s"
 }
 resource "newrelic_plugins_alert_condition" "foo" {
-	policy_id = "${newrelic_alert_policy.foo.id}"
+	policy_id = newrelic_alert_policy.foo.id
 	
 	name               = ""
 	enabled            = false
-	entities           = ["${data.newrelic_plugin_component.foo.id}"]
+	entities           = [data.newrelic_plugin_component.foo.id]
 	runbook_url        = "https://foo.example.com"
 	metric             = "Component/Connection/Clients[connections]"
 	metric_description = "my-metric-description"
-	plugin_id          = "${data.newrelic_plugin.foo.id}"
-	plugin_guid        = "${data.newrelic_plugin.foo.guid}"
+	plugin_id          = data.newrelic_plugin.foo.id
+	plugin_guid        = data.newrelic_plugin.foo.guid
 	value_function     = "average"
 	
 	term {
@@ -394,23 +394,23 @@ data "newrelic_plugin" "foo" {
 	guid = "net.kenjij.newrelic_redis_plugin"
 }
 data "newrelic_plugin_component" "foo" {
-	plugin_id = "${data.newrelic_plugin.foo.id}"
+	plugin_id = data.newrelic_plugin.foo.id
 	name = "MyRedisServer"
 }
 resource "newrelic_alert_policy" "foo" {
 	name = "tf-test-%[1]s"
 }
 resource "newrelic_plugins_alert_condition" "foo" {
-	policy_id = "${newrelic_alert_policy.foo.id}"
+	policy_id = newrelic_alert_policy.foo.id
 
 	name               = "tf-test-%[1]s"
 	enabled            = false
-	entities           = ["${data.newrelic_plugin_component.foo.id}"]
+	entities           = [data.newrelic_plugin_component.foo.id]
 	runbook_url        = "https://foo.example.com"
 	metric             = "Component/Connection/Clients[connections]"
 	metric_description = "my-metric-description"
-	plugin_id          = "${data.newrelic_plugin.foo.id}"
-	plugin_guid        = "${data.newrelic_plugin.foo.guid}"
+	plugin_id          = data.newrelic_plugin.foo.id
+	plugin_guid        = data.newrelic_plugin.foo.guid
 	value_function     = "average"
 
 	term {
@@ -448,23 +448,23 @@ data "newrelic_plugin" "foo" {
 	guid = "net.kenjij.newrelic_redis_plugin"
 }
 data "newrelic_plugin_component" "foo" {
-	plugin_id = "${data.newrelic_plugin.foo.id}"
+	plugin_id = data.newrelic_plugin.foo.id
 	name = "MyRedisServer"
 }
 resource "newrelic_alert_policy" "foo" {
 	name = "tf-test-%[1]s"
 }
 resource "newrelic_plugins_alert_condition" "foo" {
-	policy_id = "${newrelic_alert_policy.foo.id}"
+	policy_id = newrelic_alert_policy.foo.id
 
 	name               = "tf-test-%[1]s"
 	enabled            = false
-	entities           = ["${data.newrelic_plugin_component.foo.id}"]
+	entities           = [data.newrelic_plugin_component.foo.id]
 	runbook_url        = "https://foo.example.com"
 	metric             = "Component/Connection/Clients[connections]"
 	metric_description = "my-metric-description"
-	plugin_id          = "${data.newrelic_plugin.foo.id}"
-	plugin_guid        = "${data.newrelic_plugin.foo.guid}"
+	plugin_id          = data.newrelic_plugin.foo.id
+	plugin_guid        = data.newrelic_plugin.foo.guid
 	value_function     = "average"
 
 	term {

--- a/newrelic/resource_newrelic_synthetics_alert_condition_test.go
+++ b/newrelic/resource_newrelic_synthetics_alert_condition_test.go
@@ -141,9 +141,9 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_synthetics_alert_condition" "foo" {
-	policy_id   = "${newrelic_alert_policy.foo.id}"
+	policy_id   = newrelic_alert_policy.foo.id
 	name        = "tf-test-%[1]s"
-	monitor_id  = "${newrelic_synthetics_monitor.bar.id}"
+	monitor_id  = newrelic_synthetics_monitor.bar.id
 	runbook_url = "www.example.com"
 	enabled     = "true"
 }
@@ -166,9 +166,9 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_synthetics_alert_condition" "foo" {
-	policy_id   = "${newrelic_alert_policy.foo.id}"
+	policy_id   = newrelic_alert_policy.foo.id
 	name        = "tf-test-%[1]s"
-	monitor_id  = "${newrelic_synthetics_monitor.bar.id}"
+	monitor_id  = newrelic_synthetics_monitor.bar.id
 	runbook_url = "www.example-updated.com"
 	enabled     = "false"
 }

--- a/newrelic/resource_newrelic_synthetics_monitor_script_test.go
+++ b/newrelic/resource_newrelic_synthetics_monitor_script_test.go
@@ -102,7 +102,7 @@ resource "newrelic_synthetics_monitor" "foo" {
 }
 
 resource "newrelic_synthetics_monitor_script" "foo_script" {
-  monitor_id = "${newrelic_synthetics_monitor.foo.id}"
+  monitor_id = newrelic_synthetics_monitor.foo.id
   text = "%[2]s"
 }
 `, name, scriptText)

--- a/website/docs/d/alert_channel.html.markdown
+++ b/website/docs/d/alert_channel.html.markdown
@@ -25,8 +25,8 @@ resource "newrelic_alert_policy" "foo" {
 
 # Using the data source and resource together
 resource "newrelic_alert_policy_channel" "foo" {
-  policy_id  = "${newrelic_alert_policy.foo.id}"
-  channel_id = "${data.newrelic_alert_channel.foo.id}"
+  policy_id  = newrelic_alert_policy.foo.id
+  channel_id = data.newrelic_alert_channel.foo.id
 }
 ```
 

--- a/website/docs/d/alert_policy.html.markdown
+++ b/website/docs/d/alert_policy.html.markdown
@@ -23,8 +23,8 @@ data "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_alert_policy_channel" "foo" {
-  policy_id  = "${data.newrelic_alert_policy.foo.id}"
-  channel_id = "${data.newrelic_alert_channel.foo.id}"
+  policy_id  = data.newrelic_alert_policy.foo.id
+  channel_id = data.newrelic_alert_channel.foo.id
 }
 ```
 

--- a/website/docs/d/application.html.markdown
+++ b/website/docs/d/application.html.markdown
@@ -22,11 +22,11 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+  policy_id = newrelic_alert_policy.foo.id
 
   name        = "foo"
   type        = "apm_app_metric"
-  entities    = ["${data.newrelic_application.app.id}"]
+  entities    = [data.newrelic_application.app.id]
   metric      = "apdex"
   runbook_url = "https://www.example.com"
 

--- a/website/docs/d/key_transaction.html.markdown
+++ b/website/docs/d/key_transaction.html.markdown
@@ -22,11 +22,11 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+  policy_id = newrelic_alert_policy.foo.id
 
   name        = "foo"
   type        = "apm_kt_metric"
-  entities    = ["${data.newrelic_key_transaction.txn.id}"]
+  entities    = [data.newrelic_key_transaction.txn.id]
   metric      = "error_percentage"
   runbook_url = "https://www.example.com"
 

--- a/website/docs/d/plugin.html.markdown
+++ b/website/docs/d/plugin.html.markdown
@@ -24,11 +24,11 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_plugins_alert_condition" "foo" {
-  policy_id          = "${newrelic_alert_policy.foo.id}"
+  policy_id          = newrelic_alert_policy.foo.id
   name               = "foo"
   metric             = "Component/Summary/Consumers[consumers]"
-  plugin_id          = "${data.newrelic_plugin.foo.id}"
-  plugin_guid        = "${data.newrelic_plugin.foo.guid}"
+  plugin_id          = data.newrelic_plugin.foo.id
+  plugin_guid        = data.newrelic_plugin.foo.guid
   value_function     = "average"
   metric_description = "Queue consumers"
 

--- a/website/docs/d/plugin_component.html.markdown
+++ b/website/docs/d/plugin_component.html.markdown
@@ -21,7 +21,7 @@ data "newrelic_plugin" "foo" {
 }
 
 data "newrelic_plugin_component" "foo" {
-  plugin_id = "${data.newrelic_plugin.foo.id}"
+  plugin_id = data.newrelic_plugin.foo.id
   name = "My Plugin Component"
 }
 
@@ -30,12 +30,12 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_plugins_alert_condition" "foo" {
-  policy_id          = "${newrelic_alert_policy.foo.id}"
+  policy_id          = newrelic_alert_policy.foo.id
   name               = "foo"
   metric             = "Component/Summary/Consumers[consumers]"
-  plugin_id          = "${data.newrelic_plugin.foo.id}"
-  plugin_guid        = "${data.newrelic_plugin.foo.guid}"
-  entities           = ["${data.newrelic_plugin_component.foo.id}"]
+  plugin_id          = data.newrelic_plugin.foo.id
+  plugin_guid        = data.newrelic_plugin.foo.guid
+  entities           = [data.newrelic_plugin_component.foo.id]
   value_function     = "average"
   metric_description = "Queue consumers"
 

--- a/website/docs/d/synthetics_monitor.html.markdown
+++ b/website/docs/d/synthetics_monitor.html.markdown
@@ -18,10 +18,10 @@ data "newrelic_synthetics_monitor" "bar" {
 }
 
 resource "newrelic_synthetics_alert_condition" "baz" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+  policy_id = newrelic_alert_policy.foo.id
 
   name        = "baz"
-  monitor_id  = "${data.newrelic_synthetics_monitor.bar.id}"
+  monitor_id  = data.newrelic_synthetics_monitor.bar.id
   runbook_url = "https://www.example.com"
 }
 ```

--- a/website/docs/guides/getting_started.html.markdown
+++ b/website/docs/guides/getting_started.html.markdown
@@ -108,11 +108,11 @@ resource "newrelic_alert_policy" "alert_policy_name" {
 
 # Alert Condition
 resource "newrelic_alert_condition" "alert_condition_name" {
-  policy_id = "${newrelic_alert_policy.my_alert_policy_name.id}"
+  policy_id = newrelic_alert_policy.my_alert_policy_name.id
 
   name            = "My Alert Condition Name"
   type            = "apm_app_metric"
-  entities        = ["${data.newrelic_application.app_name.id}"]
+  entities        = [data.newrelic_application.app_name.id]
   metric          = "apdex"
   runbook_url     = "https://www.example.com"
   condition_scope = "application"
@@ -149,8 +149,8 @@ resource "newrelic_alert_channel" "alert_notification_email" {
 
 # Link the above notification channel to your policy
 resource "newrelic_alert_policy_channel" "alert_policy_email" {
-  policy_id  = "${newrelic_alert_policy.my_alert_policy_name.id}"
-  channel_id = "${newrelic_alert_channel.alert_notification_email.id}"
+  policy_id  = newrelic_alert_policy.my_alert_policy_name.id
+  channel_id = newrelic_alert_channel.alert_notification_email.id
 }
 ```
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -19,7 +19,12 @@ Use the navigation to the left to read about the available resources.
 ```hcl
 # Configure the New Relic provider
 provider "newrelic" {
-  api_key = "${var.newrelic_api_key}"
+  api_key = var.newrelic_api_key
+}
+
+# Read an application resource
+data "newrelic_application" "foo" {
+  name = "foo"
 }
 
 # Create an alert policy
@@ -29,11 +34,11 @@ resource "newrelic_alert_policy" "alert" {
 
 # Add a condition
 resource "newrelic_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.alert.id}"
+  policy_id = newrelic_alert_policy.alert.id
 
   name        = "foo"
   type        = "apm_app_metric"
-  entities    = ["12345"]                             # You can look this up in New Relic
+  entities    = [data.newrelic_application.foo.id]
   metric      = "apdex"
   runbook_url = "https://docs.example.com/my-runbook"
 
@@ -59,8 +64,8 @@ resource "newrelic_alert_channel" "email" {
 
 # Link the channel to the policy
 resource "newrelic_alert_policy_channel" "alert_email" {
-  policy_id  = "${newrelic_alert_policy.alert.id}"
-  channel_id = "${newrelic_alert_channel.email.id}"
+  policy_id  = newrelic_alert_policy.alert.id
+  channel_id = newrelic_alert_channel.email.id
 }
 ```
 

--- a/website/docs/r/alert_condition.html.markdown
+++ b/website/docs/r/alert_condition.html.markdown
@@ -22,11 +22,11 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+  policy_id = newrelic_alert_policy.foo.id
 
   name        = "foo"
   type        = "apm_app_metric"
-  entities    = ["${data.newrelic_application.app.id}"]
+  entities    = [data.newrelic_application.app.id]
   metric      = "apdex"
   runbook_url = "https://www.example.com"
   condition_scope = "application"

--- a/website/docs/r/alert_policy_channel.html.markdown
+++ b/website/docs/r/alert_policy_channel.html.markdown
@@ -28,8 +28,8 @@ resource "newrelic_alert_channel" "foo" {
 }
 
 resource "newrelic_alert_policy_channel" "foo" {
-  policy_id  = "${newrelic_alert_policy.foo.id}"
-  channel_id = "${newrelic_alert_channel.foo.id}"
+  policy_id  = newrelic_alert_policy.foo.id
+  channel_id = newrelic_alert_channel.foo.id
 }
 ```
 

--- a/website/docs/r/dashboard.html.markdown
+++ b/website/docs/r/dashboard.html.markdown
@@ -60,7 +60,7 @@ resource "newrelic_dashboard" "exampledash" {
     duration = 1800000
     visualization = "metric_line_chart"
     entity_ids = [
-      "${data.newrelic_application.my_application.id}",
+      data.newrelic_application.my_application.id,
     ]
     metric {
         name = "Apdex"

--- a/website/docs/r/infra_alert_condition.html.markdown
+++ b/website/docs/r/infra_alert_condition.html.markdown
@@ -18,7 +18,7 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_infra_alert_condition" "high_disk_usage" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+  policy_id = newrelic_alert_policy.foo.id
 
   name       = "High disk usage"
   type       = "infra_metric"
@@ -41,7 +41,7 @@ resource "newrelic_infra_alert_condition" "high_disk_usage" {
 }
 
 resource "newrelic_infra_alert_condition" "high_db_conn_count" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+  policy_id = newrelic_alert_policy.foo.id
 
   name       = "High database connection count"
   type       = "infra_metric"
@@ -59,7 +59,7 @@ resource "newrelic_infra_alert_condition" "high_db_conn_count" {
 }
 
 resource "newrelic_infra_alert_condition" "process_not_running" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+  policy_id = newrelic_alert_policy.foo.id
 
   name             = "Process not running (/usr/bin/ruby)"
   type             = "infra_process_running"
@@ -73,7 +73,7 @@ resource "newrelic_infra_alert_condition" "process_not_running" {
 }
 
 resource "newrelic_infra_alert_condition" "host_not_reporting" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+  policy_id = newrelic_alert_policy.foo.id
 
   name       = "Host not reporting"
   type       = "infra_host_not_reporting"

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -19,7 +19,7 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_nrql_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+  policy_id = newrelic_alert_policy.foo.id
 
   name        = "foo"
   type        = "static"
@@ -92,7 +92,7 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_nrql_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+  policy_id = newrelic_alert_policy.foo.id
 
   name        = "outlier-example"
   runbook_url = "https://bar.example.com"
@@ -125,4 +125,4 @@ $ terraform import newrelic_nrql_alert_condition.main 12345:67890
 
 The actual values for `policy_id` and `condition_id` can be retrieved from the following URL when looking at the alert condition:
 
-https://alerts.newrelic.com/accounts/<account_id>/policies/<policy_id>/conditions/<condition_id>/edit?selectedField=thresholds
+ht<span>tps://</span>alerts.newrelic.com/accounts/\<account_id\>/policies/**\<policy_id\>**/conditions/**\<condition_id\>**/edit?selectedField=thresholds

--- a/website/docs/r/plugins_alert_condition.html.markdown
+++ b/website/docs/r/plugins_alert_condition.html.markdown
@@ -22,11 +22,11 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_plugins_alert_condition" "foo" {
-  policy_id          = "${newrelic_alert_policy.foo.id}"
+  policy_id          = newrelic_alert_policy.foo.id
   name               = "foo"
   metric             = "Component/Summary/Consumers[consumers]"
-  plugin_id          = "${data.newrelic_plugin.foo.id}"
-  plugin_guid        = "${data.newrelic_plugin.foo.guid}"
+  plugin_id          = data.newrelic_plugin.foo.id
+  plugin_guid        = data.newrelic_plugin.foo.guid
   value_function     = "average"
   metric_description = "Queue consumers"
 

--- a/website/docs/r/synthetics_alert_condition.html.markdown
+++ b/website/docs/r/synthetics_alert_condition.html.markdown
@@ -18,10 +18,10 @@ data "newrelic_synthetics_monitor" "foo" {
 }
 
 resource "newrelic_synthetics_alert_condition" "foo" {
-  policy_id = "${newrelic_alert_policy.foo.id}"
+  policy_id = newrelic_alert_policy.foo.id
 
   name        = "foo"
-  monitor_id  = "${data.newrelic_synthetics_monitor.foo.id}"
+  monitor_id  = data.newrelic_synthetics_monitor.foo.id
   runbook_url = "https://www.example.com"
 }
 ```

--- a/website/docs/r/synthetics_monitor_script.html.markdown
+++ b/website/docs/r/synthetics_monitor_script.html.markdown
@@ -13,13 +13,21 @@ Use this resource to update a synthetics monitor script in New Relic.
 ## Example Usage
 
 ```hcl
+resource "newrelic_synthetics_monitor" "foo" {
+  name = "foo"
+  type = "SCRIPT_BROWSER"
+  frequency = 5
+  status = "ENABLED"
+  locations = ["AWS_US_EAST_1"]
+}
+
 data "template_file" "foo_script" {
-  template = "${file("${path.module}/foo_script.tpl")}"
+  template = file("${path.module}/foo_script.tpl")
 }
 
 resource "newrelic_synthetics_monitor_script" "foo_script" {
-  monitor_id = "${newrelic_synthetics_monitor.foo.id}"
-  text = "${data.template_file.foo_script.rendered}"
+  monitor_id = newrelic_synthetics_monitor.foo.id
+  text = data.template_file.foo_script.rendered
 }
 ```
 


### PR DESCRIPTION
This PR contains some documentation site updates before the next release.  The largest change here is removing all the deprecated HCL from the docs and tests.