### PR TITLE
Fix API Key passing to newrelic-client-go

### DIFF
--- a/newrelic/provider.go
+++ b/newrelic/provider.go
@@ -142,7 +142,7 @@ func providerConfigure(data *schema.ResourceData, terraformVersion string) (inte
 	}
 
 	log.Println("[INFO] Initializing newrelic-client-go")
-	newClient, err := nr.New(nr.ConfigUserAgent(apiKey), nr.ConfigUserAgent(userAgent))
+	newClient, err := nr.New(nr.ConfigAPIKey(apiKey), nr.ConfigUserAgent(userAgent))
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Update the config passed to newrelic-client-go to call the correct function on the API key.