### PR TITLE
docs: update alert-channel examples

### DIFF
--- a/website/docs/guides/getting_started.html.markdown
+++ b/website/docs/guides/getting_started.html.markdown
@@ -141,7 +141,7 @@ resource "newrelic_alert_channel" "alert_notification_email" {
   name = "paul@example.com"
   type = "email"
 
-  configuration = {
+  config {
     recipients              = "paul@example.com"
     include_json_attachment = "1"
   }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -56,7 +56,7 @@ resource "newrelic_alert_channel" "email" {
   name = "email"
   type = "email"
 
-  configuration = {
+  config {
     recipients              = "paul@example.com"
     include_json_attachment = "1"
   }

--- a/website/docs/r/alert_channel.html.markdown
+++ b/website/docs/r/alert_channel.html.markdown
@@ -78,7 +78,7 @@ resource "newrelic_alert_channel" "foo" {
   name = "slack-example"
   type = "slack"
 
-  configuration = {
+  config {
     url     = "https://<YourOrganization>.slack.com"
     channel = "example-alerts-channel"
   }

--- a/website/docs/r/alert_policy_channel.html.markdown
+++ b/website/docs/r/alert_policy_channel.html.markdown
@@ -21,7 +21,7 @@ resource "newrelic_alert_channel" "foo" {
   name = "foo"
   type = "email"
 
-  configuration = {
+  config {
     recipients              = "foo@example.com"
     include_json_attachment = "1"
   }


### PR DESCRIPTION
I noticed some conflicting examples (`config` vs `configuration`) when I was trying out the provider.