### PR TITLE
feat(alert_policy_channels): add ability to add multiple channels to a policy

### DIFF
--- a/newrelic/helpers.go
+++ b/newrelic/helpers.go
@@ -28,6 +28,24 @@ func parseIDs(serializedID string, count int) ([]int, error) {
 	return ids, nil
 }
 
+// Converts a hash of IDs into an array.
+// Examples: "12345:54432:66564" -> []int{12345,54432,66564}
+func parseHashedIDs(serializedID string) ([]int, error) {
+	rawIDs := strings.Split(serializedID, ":")
+	ids := make([]int, len(rawIDs))
+
+	for i, rawID := range rawIDs {
+		id, err := strconv.ParseInt(rawID, 10, 32)
+		if err != nil {
+			return ids, err
+		}
+
+		ids[i] = int(id)
+	}
+
+	return ids, nil
+}
+
 func serializeIDs(ids []int) string {
 	idStrings := make([]string, len(ids))
 

--- a/newrelic/helpers.go
+++ b/newrelic/helpers.go
@@ -3,6 +3,7 @@ package newrelic
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode"
@@ -73,4 +74,11 @@ func stripWhitespace(str string) string {
 		}
 	}
 	return b.String()
+}
+
+// Mutates original slice
+func sortIntegerSlice(integers []int) {
+	sort.Slice(integers, func(i, j int) bool {
+		return integers[i] < integers[j]
+	})
 }

--- a/newrelic/helpers_test.go
+++ b/newrelic/helpers_test.go
@@ -6,9 +6,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/stretchr/testify/require"
-
 	"github.com/newrelic/newrelic-client-go/pkg/alerts"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -29,6 +28,21 @@ func TestParseIDs_BadIDs(t *testing.T) {
 	require.Error(t, err)
 
 	_, err = parseIDs("a:b", 2)
+	require.Error(t, err)
+}
+
+func TestParseHashedIDs_Basic(t *testing.T) {
+	expected := []int{1, 2, 3}
+	result, err := parseHashedIDs("1:2:3")
+
+	require.NoError(t, err)
+	require.Equal(t, 3, len(result))
+	require.Equal(t, expected, result)
+}
+
+func TestParseHashedIDs_Invalid(t *testing.T) {
+	_, err := parseHashedIDs("123:abc")
+
 	require.Error(t, err)
 }
 

--- a/newrelic/helpers_test.go
+++ b/newrelic/helpers_test.go
@@ -60,6 +60,15 @@ func TestStripWhitespace(t *testing.T) {
 	require.Equal(t, e, a)
 }
 
+func TestSortIntegerSlice(t *testing.T) {
+	integers := []int{2, 1, 4, 3}
+	expected := []int{1, 2, 3, 4}
+
+	sortIntegerSlice(integers)
+
+	require.Equal(t, expected, integers)
+}
+
 func testAccDeleteNewRelicAlertPolicy(name string) func() {
 	return func() {
 		client := testAccProvider.Meta().(*ProviderConfig).NewClient

--- a/newrelic/provider_test.go
+++ b/newrelic/provider_test.go
@@ -3,7 +3,6 @@ package newrelic
 import (
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -114,32 +113,3 @@ func testAccCreateApplication(t *testing.T) {
 
 // 	testAccCleanupComplete = true
 // }
-
-// testCheckResourceAttr validates the value in state for the given name/key combination.
-func testCheckResourceAttr(is *terraform.InstanceState, name string, key string, value string) error {
-	// Empty containers may be elided from the state.
-	// If the intent here is to check for an empty container, allow the key to
-	// also be non-existent.
-	emptyCheck := false
-	if value == "0" && (strings.HasSuffix(key, ".#") || strings.HasSuffix(key, ".%")) {
-		emptyCheck = true
-	}
-
-	if v, ok := is.Attributes[key]; !ok || v != value {
-		if emptyCheck && !ok {
-			return nil
-		}
-
-		if !ok {
-			return fmt.Errorf("%s: Attribute '%s' not found", name, key)
-		}
-
-		return fmt.Errorf(
-			"%s: Attribute '%s' expected %#v, got %#v",
-			name,
-			key,
-			value,
-			v)
-	}
-	return nil
-}

--- a/newrelic/provider_test.go
+++ b/newrelic/provider_test.go
@@ -3,6 +3,7 @@ package newrelic
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -113,3 +114,32 @@ func testAccCreateApplication(t *testing.T) {
 
 // 	testAccCleanupComplete = true
 // }
+
+// testCheckResourceAttr validates the value in state for the given name/key combination.
+func testCheckResourceAttr(is *terraform.InstanceState, name string, key string, value string) error {
+	// Empty containers may be elided from the state.
+	// If the intent here is to check for an empty container, allow the key to
+	// also be non-existent.
+	emptyCheck := false
+	if value == "0" && (strings.HasSuffix(key, ".#") || strings.HasSuffix(key, ".%")) {
+		emptyCheck = true
+	}
+
+	if v, ok := is.Attributes[key]; !ok || v != value {
+		if emptyCheck && !ok {
+			return nil
+		}
+
+		if !ok {
+			return fmt.Errorf("%s: Attribute '%s' not found", name, key)
+		}
+
+		return fmt.Errorf(
+			"%s: Attribute '%s' expected %#v, got %#v",
+			name,
+			key,
+			value,
+			v)
+	}
+	return nil
+}

--- a/newrelic/resource_newrelic_alert_policy_channel.go
+++ b/newrelic/resource_newrelic_alert_policy_channel.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/newrelic/newrelic-client-go/newrelic"
+	"github.com/newrelic/newrelic-client-go/pkg/alerts"
 	"github.com/newrelic/newrelic-client-go/pkg/errors"
 )
 
@@ -24,9 +25,21 @@ func resourceNewRelicAlertPolicyChannel() *schema.Resource {
 				ForceNew: true,
 			},
 			"channel_id": {
-				Type:     schema.TypeInt,
-				Required: true,
-				ForceNew: true,
+				Type:          schema.TypeInt,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"channel_ids"},
+				Deprecated:    "use `channel_ids` argument instead",
+			},
+			"channel_ids": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				ForceNew:      true,
+				MinItems:      1,
+				ConflictsWith: []string{"channel_id"},
+				Elem: &schema.Schema{
+					Type: schema.TypeInt,
+				},
 			},
 		},
 	}
@@ -34,45 +47,48 @@ func resourceNewRelicAlertPolicyChannel() *schema.Resource {
 
 func resourceNewRelicAlertPolicyChannelCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ProviderConfig).NewClient
+	policyChannels, err := expandAlertPolicyChannels(d)
 
-	policyID := d.Get("policy_id").(int)
-	channelID := d.Get("channel_id").(int)
-
-	serializedID := serializeIDs([]int{policyID, channelID})
-
-	log.Printf("[INFO] Creating New Relic alert policy channel %s", serializedID)
-
-	exists, err := policyChannelExists(client, policyID, channelID)
 	if err != nil {
 		return err
 	}
 
-	if !exists {
-		_, err = client.Alerts.UpdatePolicyChannels(policyID, []int{channelID})
-		if err != nil {
-			return err
-		}
+	serializedID := serializeIDs(append(
+		[]int{policyChannels.ID},
+		policyChannels.ChannelIDs...,
+	))
+
+	log.Printf("[INFO] Creating New Relic alert policy channel %s", serializedID)
+
+	_, err = client.Alerts.UpdatePolicyChannels(
+		policyChannels.ID,
+		policyChannels.ChannelIDs,
+	)
+
+	if err != nil {
+		return err
 	}
 
 	d.SetId(serializedID)
 
-	return nil
+	return resourceNewRelicAlertPolicyChannelRead(d, meta)
 }
 
 func resourceNewRelicAlertPolicyChannelRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ProviderConfig).NewClient
 
-	ids, err := parseIDs(d.Id(), 2)
+	ids, err := parseHashedIDs(d.Id())
 	if err != nil {
 		return err
 	}
 
 	policyID := ids[0]
-	channelID := ids[1]
+	parsedChannelIDs := ids[1:]
 
 	log.Printf("[INFO] Reading New Relic alert policy channel %s", d.Id())
 
-	exists, err := policyChannelExists(client, policyID, channelID)
+	exists, err := policyChannelsExist(client, policyID, parsedChannelIDs)
+
 	if err != nil {
 		return err
 	}
@@ -83,7 +99,22 @@ func resourceNewRelicAlertPolicyChannelRead(d *schema.ResourceData, meta interfa
 	}
 
 	d.Set("policy_id", policyID)
-	d.Set("channel_id", channelID)
+
+	_, channelIDOk := d.GetOk("channel_id")
+	_, channelIDsOk := d.GetOk("channel_ids")
+
+	if channelIDOk && len(parsedChannelIDs) == 1 {
+		d.Set("channel_id", parsedChannelIDs[0])
+	}
+
+	if channelIDsOk && len(parsedChannelIDs) > 0 {
+		d.Set("channel_ids", parsedChannelIDs)
+	}
+
+	// Handle import (set `channel_ids` since this resource doesn't exist in state yet)
+	if !channelIDOk && !channelIDsOk {
+		d.Set("channel_ids", parsedChannelIDs)
+	}
 
 	return nil
 }
@@ -91,48 +122,80 @@ func resourceNewRelicAlertPolicyChannelRead(d *schema.ResourceData, meta interfa
 func resourceNewRelicAlertPolicyChannelDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ProviderConfig).NewClient
 
-	ids, err := parseIDs(d.Id(), 2)
+	ids, err := parseHashedIDs(d.Id())
 	if err != nil {
 		return err
 	}
 
 	policyID := ids[0]
-	channelID := ids[1]
+	channelIDs := ids[1:]
 
 	log.Printf("[INFO] Deleting New Relic alert policy channel %s", d.Id())
 
-	exists, err := policyChannelExists(client, policyID, channelID)
+	exists, err := policyChannelsExist(client, policyID, channelIDs)
 	if err != nil {
 		return err
 	}
 
 	if exists {
-		if _, err := client.Alerts.DeletePolicyChannel(policyID, channelID); err != nil {
-			if _, ok := err.(*errors.NotFound); ok {
-				return nil
+		for _, id := range channelIDs {
+			if _, err := client.Alerts.DeletePolicyChannel(policyID, id); err != nil {
+				if _, ok := err.(*errors.NotFound); ok {
+					return nil
+				}
+				return err
 			}
-			return err
 		}
 	}
 
 	return nil
 }
 
-func policyChannelExists(client *newrelic.NewRelic, policyID int, channelID int) (bool, error) {
-	channel, err := client.Alerts.GetChannel(channelID)
-	if err != nil {
-		if _, ok := err.(*errors.NotFound); ok {
-			return false, nil
-		}
+func policyChannelsExist(
+	client *newrelic.NewRelic,
+	policyID int,
+	channelIDs []int,
+) (bool, error) {
+	channels, err := client.Alerts.ListChannels()
 
+	if err != nil {
 		return false, err
 	}
 
-	for _, id := range channel.Links.PolicyIDs {
-		if id == policyID {
-			return true, nil
+	var foundChannels []*alerts.Channel
+	for _, id := range channelIDs {
+		ch := findChannel(channels, id)
+
+		if ch == nil {
+			return false, nil
+		}
+
+		foundChannels = append(foundChannels, ch)
+	}
+
+	var policyChannelsCount int
+	for _, channel := range foundChannels {
+		for _, id := range channel.Links.PolicyIDs {
+			if id == policyID {
+				policyChannelsCount++
+			}
 		}
 	}
 
+	// Ensure all channels exist on the policy
+	if policyChannelsCount == len(channelIDs) {
+		return true, nil
+	}
+
 	return false, nil
+}
+
+func findChannel(channels []*alerts.Channel, id int) *alerts.Channel {
+	for _, channel := range channels {
+		if channel.ID == id {
+			return channel
+		}
+	}
+
+	return nil
 }

--- a/newrelic/resource_newrelic_alert_policy_channel.go
+++ b/newrelic/resource_newrelic_alert_policy_channel.go
@@ -53,6 +53,8 @@ func resourceNewRelicAlertPolicyChannelCreate(d *schema.ResourceData, meta inter
 		return err
 	}
 
+	sortIntegerSlice(policyChannels.ChannelIDs)
+
 	serializedID := serializeIDs(append(
 		[]int{policyChannels.ID},
 		policyChannels.ChannelIDs...,
@@ -84,6 +86,8 @@ func resourceNewRelicAlertPolicyChannelRead(d *schema.ResourceData, meta interfa
 
 	policyID := ids[0]
 	parsedChannelIDs := ids[1:]
+
+	sortIntegerSlice(parsedChannelIDs)
 
 	log.Printf("[INFO] Reading New Relic alert policy channel %s", d.Id())
 

--- a/newrelic/resource_newrelic_alert_policy_channel.go
+++ b/newrelic/resource_newrelic_alert_policy_channel.go
@@ -102,25 +102,7 @@ func resourceNewRelicAlertPolicyChannelRead(d *schema.ResourceData, meta interfa
 		return nil
 	}
 
-	d.Set("policy_id", policyID)
-
-	_, channelIDOk := d.GetOk("channel_id")
-	_, channelIDsOk := d.GetOk("channel_ids")
-
-	if channelIDOk && len(parsedChannelIDs) == 1 {
-		d.Set("channel_id", parsedChannelIDs[0])
-	}
-
-	if channelIDsOk && len(parsedChannelIDs) > 0 {
-		d.Set("channel_ids", parsedChannelIDs)
-	}
-
-	// Handle import (set `channel_ids` since this resource doesn't exist in state yet)
-	if !channelIDOk && !channelIDsOk {
-		d.Set("channel_ids", parsedChannelIDs)
-	}
-
-	return nil
+	return flattenAlertPolicyChannels(d, policyID, parsedChannelIDs)
 }
 
 func resourceNewRelicAlertPolicyChannelDelete(d *schema.ResourceData, meta interface{}) error {

--- a/newrelic/resource_newrelic_alert_policy_channel_test.go
+++ b/newrelic/resource_newrelic_alert_policy_channel_test.go
@@ -36,7 +36,7 @@ func TestAccNewRelicAlertPolicyChannel_Basic(t *testing.T) {
 			{
 				ResourceName:     resourceName,
 				ImportState:      true,
-				ImportStateCheck: testAccNewRelicAlertPolicyImportStateCheckFunc(),
+				ImportStateCheck: testAccNewRelicAlertPolicyImportStateCheckFunc(resourceName),
 			},
 		},
 	})
@@ -178,10 +178,22 @@ func testAccCheckNewRelicAlertPolicyChannelExists(n string) resource.TestCheckFu
 	}
 }
 
-func testAccNewRelicAlertPolicyImportStateCheckFunc() resource.ImportStateCheckFunc {
+func testAccNewRelicAlertPolicyImportStateCheckFunc(resourceName string) resource.ImportStateCheckFunc {
 	return func(state []*terraform.InstanceState) error {
-		// Ensure import sets `channel_ids`
-		return testCheckResourceAttr(state[0], "newrelic_alert_policy_channel.foo", "channel_ids.#", "1")
+		expectedChannelsCount := "1"
+		channelsCount := state[0].Attributes["channel_ids.#"]
+
+		if channelsCount != expectedChannelsCount {
+			return fmt.Errorf(
+				"%s: Attribute '%s' expected %#v, got %#v",
+				resourceName,
+				"channel_ids.#",
+				expectedChannelsCount,
+				channelsCount,
+			)
+		}
+
+		return nil
 	}
 }
 

--- a/newrelic/resource_newrelic_alert_policy_channel_test.go
+++ b/newrelic/resource_newrelic_alert_policy_channel_test.go
@@ -12,6 +12,7 @@ import (
 func TestAccNewRelicAlertPolicyChannel_Basic(t *testing.T) {
 	resourceName := "newrelic_alert_policy_channel.foo"
 	rName := acctest.RandString(5)
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -21,7 +22,7 @@ func TestAccNewRelicAlertPolicyChannel_Basic(t *testing.T) {
 			{
 				Config: testAccNewRelicAlertPolicyChannelConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicAlertPolicyChannelExists("newrelic_alert_policy_channel.foo"),
+					testAccCheckNewRelicAlertPolicyChannelExists(resourceName),
 				),
 			},
 			// Test: Update
@@ -29,6 +30,39 @@ func TestAccNewRelicAlertPolicyChannel_Basic(t *testing.T) {
 				Config: testAccNewRelicAlertPolicyChannelConfigUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicAlertPolicyChannelExists("newrelic_alert_policy_channel.foo"),
+				),
+			},
+			// Test: Import
+			{
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateCheck: testAccNewRelicAlertPolicyImportStateCheckFunc(),
+			},
+		},
+	})
+}
+
+func TestAccNewRelicAlertPolicyChannel_MutipleChannels(t *testing.T) {
+	resourceName := "newrelic_alert_policy_channel.foo"
+	rName := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertPolicyChannelDestroy,
+		Steps: []resource.TestStep{
+			// Test: Create
+			{
+				Config: testAccNewRelicAlertPolicyChannelsConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAlertPolicyChannelExists(resourceName),
+				),
+			},
+			// Test: Update
+			{
+				Config: testAccNewRelicAlertPolicyChannelsConfigUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAlertPolicyChannelExists(resourceName),
 				),
 			},
 			// Test: Import
@@ -92,15 +126,15 @@ func testAccCheckNewRelicAlertPolicyChannelDestroy(s *terraform.State) error {
 			continue
 		}
 
-		ids, err := parseIDs(r.Primary.ID, 2)
+		ids, err := parseHashedIDs(r.Primary.ID)
 		if err != nil {
 			return err
 		}
 
 		policyID := ids[0]
-		channelID := ids[1]
+		channelIDs := ids[1:]
 
-		exists, err := policyChannelExists(client, policyID, channelID)
+		exists, err := policyChannelsExist(client, policyID, channelIDs)
 		if err != nil {
 			return err
 		}
@@ -124,15 +158,15 @@ func testAccCheckNewRelicAlertPolicyChannelExists(n string) resource.TestCheckFu
 
 		client := testAccProvider.Meta().(*ProviderConfig).NewClient
 
-		ids, err := parseIDs(rs.Primary.ID, 2)
+		ids, err := parseHashedIDs(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
 
 		policyID := ids[0]
-		channelID := ids[1]
+		channelIDs := ids[1:]
 
-		exists, err := policyChannelExists(client, policyID, channelID)
+		exists, err := policyChannelsExist(client, policyID, channelIDs)
 		if err != nil {
 			return err
 		}
@@ -141,6 +175,13 @@ func testAccCheckNewRelicAlertPolicyChannelExists(n string) resource.TestCheckFu
 		}
 
 		return nil
+	}
+}
+
+func testAccNewRelicAlertPolicyImportStateCheckFunc() resource.ImportStateCheckFunc {
+	return func(state []*terraform.InstanceState) error {
+		// Ensure import sets `channel_ids`
+		return testCheckResourceAttr(state[0], "newrelic_alert_policy_channel.foo", "channel_ids.#", "1")
 	}
 }
 
@@ -153,7 +194,7 @@ resource "newrelic_alert_policy" "foo" {
 resource "newrelic_alert_channel" "foo" {
   name = "%[1]s"
 	type = "email"
-	
+
 	config {
 		recipients = "terraform-acctest+foo@hashicorp.com"
 		include_json_attachment = "1"
@@ -176,7 +217,7 @@ resource "newrelic_alert_policy" "foo" {
 resource "newrelic_alert_channel" "foo" {
   name = "tf-test-updated-%[1]s"
 	type = "email"
-	
+
 	config {
 		recipients = "terraform-acctest+bar@hashicorp.com"
 		include_json_attachment = "0"
@@ -188,4 +229,61 @@ resource "newrelic_alert_policy_channel" "foo" {
   channel_id = newrelic_alert_channel.foo.id
 }
 `, rName)
+}
+
+func testAccNewRelicAlertPolicyChannelsConfig(name string) string {
+	return fmt.Sprintf(`
+resource "newrelic_alert_policy" "foo" {
+  name = "tf-test-%[1]s"
+}
+
+resource "newrelic_alert_channel" "foo" {
+  name = "tf-test-%[1]s"
+	type = "email"
+	config {
+		recipients = "terraform-acctest+foo@hashicorp.com"
+		include_json_attachment = "1"
+	}
+}
+
+resource "newrelic_alert_policy_channel" "foo" {
+  policy_id  = newrelic_alert_policy.foo.id
+  channel_ids = [
+		newrelic_alert_channel.foo.id
+	]
+}
+`, name)
+}
+
+func testAccNewRelicAlertPolicyChannelsConfigUpdated(name string) string {
+	return fmt.Sprintf(`
+resource "newrelic_alert_policy" "foo" {
+  name = "tf-test-%[1]s"
+}
+
+resource "newrelic_alert_channel" "foo" {
+  name = "tf-test-%[1]s"
+	type = "email"
+	config {
+		recipients = "terraform-acctest+foo@hashicorp.com"
+		include_json_attachment = "1"
+	}
+}
+
+resource "newrelic_alert_channel" "bar" {
+  name = "tf-test-2-%[1]s"
+	type = "email"
+	config {
+		recipients = "terraform-acctest+bar@hashicorp.com"
+	}
+}
+
+resource "newrelic_alert_policy_channel" "foo" {
+  policy_id  = newrelic_alert_policy.foo.id
+  channel_ids = [
+		newrelic_alert_channel.foo.id,
+		newrelic_alert_channel.bar.id
+	]
+}
+`, name)
 }

--- a/newrelic/structures_newrelic_alert_policy_channel.go
+++ b/newrelic/structures_newrelic_alert_policy_channel.go
@@ -40,3 +40,25 @@ func expandChannelIDs(channelIDs []interface{}) []int {
 
 	return ids
 }
+
+func flattenAlertPolicyChannels(d *schema.ResourceData, policyID int, channelIDs []int) error {
+	d.Set("policy_id", policyID)
+
+	_, channelIDOk := d.GetOk("channel_id")
+	_, channelIDsOk := d.GetOk("channel_ids")
+
+	if channelIDOk && len(channelIDs) == 1 {
+		d.Set("channel_id", channelIDs[0])
+	}
+
+	if channelIDsOk && len(channelIDs) > 0 {
+		d.Set("channel_ids", channelIDs)
+	}
+
+	// Handle import (set `channel_ids` since this resource doesn't exist in state yet)
+	if !channelIDOk && !channelIDsOk {
+		d.Set("channel_ids", channelIDs)
+	}
+
+	return nil
+}

--- a/newrelic/structures_newrelic_alert_policy_channel.go
+++ b/newrelic/structures_newrelic_alert_policy_channel.go
@@ -1,0 +1,42 @@
+package newrelic
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/newrelic/newrelic-client-go/pkg/alerts"
+)
+
+func expandAlertPolicyChannels(d *schema.ResourceData) (*alerts.PolicyChannels, error) {
+	channelID := d.Get("channel_id").(int)
+	channelIDs := d.Get("channel_ids").([]interface{})
+
+	if channelID == 0 && len(channelIDs) == 0 {
+		return nil, fmt.Errorf("must provide channel_id or channel_ids for resource newrelic_alert_policy_channel")
+	}
+
+	var ids []int
+
+	if channelID != 0 {
+		ids = []int{channelID}
+	} else {
+		ids = expandChannelIDs(channelIDs)
+	}
+
+	policyChannels := alerts.PolicyChannels{
+		ID:         d.Get("policy_id").(int),
+		ChannelIDs: ids,
+	}
+
+	return &policyChannels, nil
+}
+
+func expandChannelIDs(channelIDs []interface{}) []int {
+	ids := make([]int, len(channelIDs))
+
+	for i := range ids {
+		ids[i] = channelIDs[i].(int)
+	}
+
+	return ids
+}

--- a/newrelic/structures_newrelic_alert_policy_channel_test.go
+++ b/newrelic/structures_newrelic_alert_policy_channel_test.go
@@ -10,7 +10,7 @@ func TestExpandChannelIDs(t *testing.T) {
 	flattened := []interface{}{123, 456}
 	expected := []int{123, 456}
 
-	expanded := expandAlertChannelIDs(flattened)
+	expanded := expandChannelIDs(flattened)
 
 	require.NotNil(t, expanded)
 	require.Equal(t, expected, expanded)

--- a/website/docs/r/alert_policy_channel.html.markdown
+++ b/website/docs/r/alert_policy_channel.html.markdown
@@ -1,12 +1,12 @@
 ---
-layout: "newrelic"
-page_title: "New Relic: newrelic_alert_policy_channel"
-sidebar_current: "docs-newrelic-resource-alert-policy-channel"
+layout: 'newrelic'
+page_title: 'New Relic: newrelic_alert_policy_channel'
+sidebar_current: 'docs-newrelic-resource-alert-policy-channel'
 description: |-
   Map alert policies to alert channels in New Relic.
 ---
 
-# Resource: newrelic\_alert\_policy\_channel
+# Resource: newrelic_alert_policy_channel
 
 Use this resource to map alert policies to alert channels in New Relic.
 
@@ -58,9 +58,9 @@ resource "newrelic_alert_policy_channel" "foo" {
 
 The following arguments are supported:
 
-  * `policy_id` - (Required) The ID of the policy.
-  * `channel_ids` - (Optional*) Array of channel IDs to apply to the specified policy.
-  * `channel_id` - **Deprecated!** (Optional*) The ID of the channel. Please use the `channel_ids` argument instead.
+- `policy_id` - (Required) The ID of the policy.
+- `channel_ids` - (Optional\*) Array of channel IDs to apply to the specified policy. We recommended sorting channel IDs in ascending order to avoid drift your Terraform state.
+- `channel_id` - **Deprecated!** (Optional\*) The ID of the channel. Please use the `channel_ids` argument instead.
 
 <sup>\*Note: Even though **channel_id** and **channel_ids** are optional, at least one of those arguments must be used for this resource to work.</sup>
 
@@ -72,6 +72,6 @@ Alert policy channels can be imported using the following notation: `<policyID>:
 $ terraform import newrelic_alert_policy_channel.foo 123456:3462754:2938324
 ```
 
-When importing `newrelic_alert_policy_channel` resource, the attribute `channel_ids`* will be set in your Terraform state. You can import multiple channels as long as those channel IDs are included as part of the import ID hash.
+When importing `newrelic_alert_policy_channel` resource, the attribute `channel_ids`\* will be set in your Terraform state. You can import multiple channels as long as those channel IDs are included as part of the import ID hash.
 
 <sup>\*Note: The attribute **channel_id** is _deprecated_ and will not be set when importing this resource.</sup>


### PR DESCRIPTION
Resolves: #319 

This PR introduces the ability to provision multiple alert channels per a policy via the `/v2/alerts_policy_channels` endpoint. Prior to this, we could only provision a single channel per HCL block. This will greatly reduce the amount of HCL code required to accomplish adding multiple notification channels to a policy.  