### PR TITLE
Fix/alert channel webhooks

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -252,7 +252,6 @@ github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20191115094559-17f92b0546e8 h1:+RyjwU+Gnd/aTJBPZVDNm903eXVjjqhbaR4Ypx3xYyY=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20191115094559-17f92b0546e8/go.mod h1:p+ivJws3dpqbp1iP84+npOyAmTTOLMgCzrXd3GSdn/A=
-github.com/hashicorp/terraform-plugin-sdk v1.5.0/go.mod h1:H5QLx/uhwfxBZ59Bc5SqT19M4i+fYt7LZjHTpbLZiAg=
 github.com/hashicorp/terraform-plugin-sdk v1.6.0 h1:Um5hsAL7kKsfTHtan8lybY/d03F2bHu4fjRB1H6Ag4U=
 github.com/hashicorp/terraform-plugin-sdk v1.6.0/go.mod h1:H5QLx/uhwfxBZ59Bc5SqT19M4i+fYt7LZjHTpbLZiAg=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596 h1:hjyO2JsNZUKT1ym+FAdlBEkGPevazYsmVgIMw7dVELg=
@@ -366,7 +365,6 @@ github.com/mozilla/tls-observatory v0.0.0-20190404164649-a3c1b6cfecfd/go.mod h1:
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d h1:AREM5mwr4u1ORQBMvzfzBgpsctsbQikCVpvC+tX285E=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
-github.com/newrelic/go-agent/v3 v3.1.0/go.mod h1:H28zDNUC0U/b7kLoY4EFOhuth10Xu/9dchozUiOseQQ=
 github.com/newrelic/go-agent/v3 v3.2.0 h1:VyVCJYgqNCMSa5b92dcREL7fxNIobTw6DVolTWJDJJs=
 github.com/newrelic/go-agent/v3 v3.2.0/go.mod h1:H28zDNUC0U/b7kLoY4EFOhuth10Xu/9dchozUiOseQQ=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=

--- a/newrelic/helpers.go
+++ b/newrelic/helpers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 func parseIDs(serializedID string, count int) ([]int, error) {
@@ -43,4 +44,15 @@ func toJSON(data interface{}) string {
 	c, _ := json.MarshalIndent(data, "", "  ")
 
 	return string(c)
+}
+
+func stripWhitespace(str string) string {
+	var b strings.Builder
+	b.Grow(len(str))
+	for _, ch := range str {
+		if !unicode.IsSpace(ch) {
+			b.WriteRune(ch)
+		}
+	}
+	return b.String()
 }

--- a/newrelic/helpers_test.go
+++ b/newrelic/helpers_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/stretchr/testify/require"
 
 	"github.com/newrelic/newrelic-client-go/pkg/alerts"
 )
@@ -16,37 +17,33 @@ var (
 
 func TestParseIDs_Basic(t *testing.T) {
 	ids, err := parseIDs("1:2", 2)
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	if len(ids) != 2 {
-		t.Fatal(len(ids))
-	}
-
-	if ids[0] != 1 || ids[1] != 2 {
-		t.Fatal(ids)
-	}
+	require.NoError(t, err)
+	require.Equal(t, 2, len(ids))
+	require.Equal(t, 1, ids[0])
+	require.Equal(t, 2, ids[1])
 }
 
 func TestParseIDs_BadIDs(t *testing.T) {
 	_, err := parseIDs("12", 2)
-	if err == nil {
-		t.Fatal(err)
-	}
+	require.Error(t, err)
 
 	_, err = parseIDs("a:b", 2)
-	if err == nil {
-		t.Fatal(err)
-	}
+	require.Error(t, err)
 }
 
 func TestSerializeIDs_Basic(t *testing.T) {
 	id := serializeIDs([]int{1, 2})
 
-	if id != "1:2" {
-		t.Fatal(id)
-	}
+	require.Equal(t, "1:2", id)
+}
+
+func TestStripWhitespace(t *testing.T) {
+	json := " { \"key\": \"value\" } "
+	e := "{\"key\":\"value\"}"
+	a := stripWhitespace(json)
+
+	require.Equal(t, e, a)
 }
 
 func testAccDeleteNewRelicAlertPolicy(name string) func() {

--- a/newrelic/resource_newrelic_alert_channel.go
+++ b/newrelic/resource_newrelic_alert_channel.go
@@ -3,8 +3,6 @@ package newrelic
 import (
 	"log"
 	"strconv"
-	"strings"
-	"unicode"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -140,7 +138,7 @@ func resourceNewRelicAlertChannel() *schema.Resource {
 							ConflictsWith: []string{"config.0.headers"},
 							// Suppress the diff shown if the differences are solely due to whitespace
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								return StripWhitespace(old) == StripWhitespace(new)
+								return stripWhitespace(old) == stripWhitespace(new)
 							},
 						},
 						"key": {
@@ -170,7 +168,7 @@ func resourceNewRelicAlertChannel() *schema.Resource {
 							ConflictsWith: []string{"config.0.payload"},
 							// Suppress the diff shown if the differences are solely due to whitespace
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								return StripWhitespace(old) == StripWhitespace(new)
+								return stripWhitespace(old) == stripWhitespace(new)
 							},
 						},
 						"payload_type": {
@@ -287,16 +285,4 @@ func resourceNewRelicAlertChannelDelete(d *schema.ResourceData, meta interface{}
 	}
 
 	return nil
-}
-
-// StripWhitespace removes whitespace from a string.
-func StripWhitespace(str string) string {
-	var b strings.Builder
-	b.Grow(len(str))
-	for _, ch := range str {
-		if !unicode.IsSpace(ch) {
-			b.WriteRune(ch)
-		}
-	}
-	return b.String()
 }

--- a/newrelic/resource_newrelic_alert_channel.go
+++ b/newrelic/resource_newrelic_alert_channel.go
@@ -129,13 +129,14 @@ func resourceNewRelicAlertChannel() *schema.Resource {
 							Elem:          &schema.Schema{Type: schema.TypeString},
 							Optional:      true,
 							Sensitive:     true,
-							ForceNew:  true,
+							ForceNew:      true,
 							ConflictsWith: []string{"config.0.headers_string"},
 						},
 						"headers_string": {
 							Type:          schema.TypeString,
 							Optional:      true,
 							Sensitive:     true,
+							ForceNew:      true,
 							ConflictsWith: []string{"config.0.headers"},
 							// Suppress the diff shown if the differences are solely due to whitespace
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
@@ -158,13 +159,14 @@ func resourceNewRelicAlertChannel() *schema.Resource {
 							Elem:          &schema.Schema{Type: schema.TypeString},
 							Sensitive:     true,
 							Optional:      true,
-							ForceNew:  true,
+							ForceNew:      true,
 							ConflictsWith: []string{"config.0.payload_string"},
 						},
 						"payload_string": {
 							Type:          schema.TypeString,
 							Optional:      true,
 							Sensitive:     true,
+							ForceNew:      true,
 							ConflictsWith: []string{"config.0.payload"},
 							// Suppress the diff shown if the differences are solely due to whitespace
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {

--- a/newrelic/resource_newrelic_alert_channel_test.go
+++ b/newrelic/resource_newrelic_alert_channel_test.go
@@ -415,45 +415,6 @@ func TestAccNewRelicAlertChannel_VictorOps(t *testing.T) {
 	})
 }
 
-func TestAccNewRelicAlertChannel_WebhookComplexPayload(t *testing.T) {
-	resourceName := "newrelic_alert_channel.foo"
-	rand := acctest.RandString(5)
-	rName := fmt.Sprintf("tf-test-%s", rand)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNewRelicAlertChannelDestroy,
-		Steps: []resource.TestStep{
-			// Test: Create
-			{
-				Config: testAccNewRelicAlertChannelConfigByType(rName, "webhook", `{
-					base_url = "https://example.com"
-					payload_type = "application/json"
-					payload = {
-						"string" = "string"
-						"object" = "{ \"key\": \"value\" }"
-						"array" = "[1,2,3]"
-					}
-				}`),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicAlertChannelExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "type", "webhook"),
-					resource.TestCheckResourceAttr(resourceName, "config.0.base_url", "https://example.com"),
-					resource.TestCheckResourceAttr(resourceName, "config.0.payload_type", "application/json"),
-				),
-			},
-			// Test: Import
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccNewRelicAlertChannel_WebhookPayloadValidation(t *testing.T) {
 	rand := acctest.RandString(5)
 	rName := fmt.Sprintf("tf-test-%s", rand)

--- a/newrelic/resource_newrelic_alert_channel_test.go
+++ b/newrelic/resource_newrelic_alert_channel_test.go
@@ -93,6 +93,99 @@ func TestAccNewRelicAlertChannel_Basic(t *testing.T) {
 	})
 }
 
+func TestAccNewRelicAlertChannel_Webhook(t *testing.T) {
+	resourceName := "newrelic_alert_channel.foo"
+	rand := acctest.RandString(5)
+	rName := fmt.Sprintf("tf-test-%s", rand)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertChannelDestroy,
+		Steps: []resource.TestStep{
+			// Test: Create
+			{
+				Config: testAccNewRelicAlertChannelConfigByType(rName, "webhook", `{
+					base_url = "http://www.test.com"
+					payload_type = "application/json"
+					payload = {
+						"test": "value"
+					}
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAlertChannelExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNewRelicAlertChannel_WebhookPayloadHeaderStringConflicts(t *testing.T) {
+	rand := acctest.RandString(5)
+	rName := fmt.Sprintf("tf-test-%s", rand)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertChannelDestroy,
+		Steps: []resource.TestStep{
+			// Test: Headers attribute conflict
+			{
+				Config: testAccNewRelicAlertChannelConfigByType(rName, "webhook", `{
+					base_url = "http://www.test.com"
+					payload_type = "application/json"
+					payload = {
+						test = "value"
+					}
+					headers_string = "{ \"test\": { \"some\": \"value\" } }"
+					headers = {
+						test = "value"
+					}
+				}`),
+				ExpectError: regexp.MustCompile("conflicts with"),
+			},
+			// Test: Payload attribute conflict
+			{
+				Config: testAccNewRelicAlertChannelConfigByType(rName, "webhook", `{
+					base_url = "http://www.test.com"
+					payload_type = "application/json"
+					payload_string = "{ \"test\": { \"some\": \"value\" } }"
+					payload = {
+						test = "value"
+					}
+				}`),
+				ExpectError: regexp.MustCompile("conflicts with"),
+			},
+		},
+	})
+}
+
+func TestAccNewRelicAlertChannel_WebhookPayloadHeaderString(t *testing.T) {
+	resourceName := "newrelic_alert_channel.foo"
+	rand := acctest.RandString(5)
+	rName := fmt.Sprintf("tf-test-%s", rand)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNewRelicAlertChannelConfigByType(rName, "webhook", `{
+					base_url = "http://www.test.com"
+					payload_type = "application/json"
+					payload_string = "{ \"test\": { \"some\": \"value\" } }"
+					headers_string = "{ \"test\": { \"some\": \"value\" } }"
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAlertChannelExists(resourceName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNewRelicAlertChannel_Slack(t *testing.T) {
 	resourceName := "newrelic_alert_channel.foo"
 	rand := acctest.RandString(5)

--- a/newrelic/structures_newrelic_alert_channel.go
+++ b/newrelic/structures_newrelic_alert_channel.go
@@ -51,6 +51,7 @@ func expandAlertChannel(d *schema.ResourceData) (*alerts.Channel, error) {
 	return &channel, nil
 }
 
+//nolint:gocyclo
 func expandAlertChannelConfiguration(cfg map[string]interface{}) (*alerts.ChannelConfiguration, error) {
 	config := alerts.ChannelConfiguration{}
 
@@ -167,8 +168,11 @@ func flattenAlertChannel(channel *alerts.Channel, d *schema.ResourceData) error 
 	d.Set("type", channel.Type)
 
 	config, err := flattenAlertChannelConfiguration(&channel.Configuration, d)
-	configuration, err := flattenDeprecatedAlertChannelConfiguration(&channel.Configuration)
+	if err != nil {
+		return err
+	}
 
+	configuration, err := flattenDeprecatedAlertChannelConfiguration(&channel.Configuration)
 	if err != nil {
 		return err
 	}

--- a/newrelic/structures_newrelic_alert_channel.go
+++ b/newrelic/structures_newrelic_alert_channel.go
@@ -23,11 +23,23 @@ func expandAlertChannel(d *schema.ResourceData) (*alerts.Channel, error) {
 	}
 
 	if configOk {
-		channel.Configuration = expandAlertChannelConfiguration(config.([]interface{})[0].(map[string]interface{}))
+		c, err := expandAlertChannelConfiguration(config.([]interface{})[0].(map[string]interface{}))
+
+		if err != nil {
+			return nil, err
+		}
+
+		channel.Configuration = *c
 	}
 
 	if configurationOk {
-		channel.Configuration = expandAlertChannelConfiguration(configuration.(map[string]interface{}))
+		c, err := expandAlertChannelConfiguration(configuration.(map[string]interface{}))
+
+		if err != nil {
+			return nil, err
+		}
+
+		channel.Configuration = *c
 	}
 
 	err := validateChannelConfiguration(channel.Configuration)
@@ -39,7 +51,7 @@ func expandAlertChannel(d *schema.ResourceData) (*alerts.Channel, error) {
 	return &channel, nil
 }
 
-func expandAlertChannelConfiguration(cfg map[string]interface{}) alerts.ChannelConfiguration {
+func expandAlertChannelConfiguration(cfg map[string]interface{}) (*alerts.ChannelConfiguration, error) {
 	config := alerts.ChannelConfiguration{}
 
 	if apiKey, ok := cfg["api_key"]; ok {
@@ -71,12 +83,36 @@ func expandAlertChannelConfiguration(cfg map[string]interface{}) alerts.ChannelC
 		config.Headers = h
 	}
 
+	if headers, ok := cfg["headers_string"]; ok && headers != "" {
+		s := []byte(headers.(string))
+		var h map[string]interface{}
+		err := json.Unmarshal(s, &h)
+
+		if err != nil {
+			return nil, err
+		}
+
+		config.Headers = h
+	}
+
 	if includeJSONAttachment, ok := cfg["include_json_attachment"]; ok {
 		config.IncludeJSONAttachment = includeJSONAttachment.(string)
 	}
 
 	if payload, ok := cfg["payload"]; ok {
 		p := payload.(map[string]interface{})
+		config.Payload = p
+	}
+
+	if payload, ok := cfg["payload_string"]; ok && payload != "" {
+		s := []byte(payload.(string))
+		var p map[string]interface{}
+		err := json.Unmarshal(s, &p)
+
+		if err != nil {
+			return nil, err
+		}
+
 		config.Payload = p
 	}
 
@@ -116,7 +152,7 @@ func expandAlertChannelConfiguration(cfg map[string]interface{}) alerts.ChannelC
 		config.UserID = userID.(string)
 	}
 
-	return config
+	return &config, nil
 }
 
 func flattenAlertChannelDataSource(channel *alerts.Channel, d *schema.ResourceData) error {
@@ -130,7 +166,7 @@ func flattenAlertChannel(channel *alerts.Channel, d *schema.ResourceData) error 
 	d.Set("name", channel.Name)
 	d.Set("type", channel.Type)
 
-	config := flattenAlertChannelConfiguration(&channel.Configuration)
+	config, err := flattenAlertChannelConfiguration(&channel.Configuration, d)
 	configuration, err := flattenDeprecatedAlertChannelConfiguration(&channel.Configuration)
 
 	if err != nil {
@@ -150,9 +186,9 @@ func flattenAlertChannel(channel *alerts.Channel, d *schema.ResourceData) error 
 	return nil
 }
 
-func flattenAlertChannelConfiguration(c *alerts.ChannelConfiguration) []interface{} {
+func flattenAlertChannelConfiguration(c *alerts.ChannelConfiguration, d *schema.ResourceData) ([]interface{}, error) {
 	if c == nil {
-		return nil
+		return nil, nil
 	}
 
 	configResult := make(map[string]interface{})
@@ -163,9 +199,7 @@ func flattenAlertChannelConfiguration(c *alerts.ChannelConfiguration) []interfac
 	configResult["base_url"] = c.BaseURL
 	configResult["channel"] = c.Channel
 	configResult["key"] = c.Key
-	configResult["headers"] = c.Headers
 	configResult["include_json_attachment"] = c.IncludeJSONAttachment
-	configResult["payload"] = c.Payload
 	configResult["payload_type"] = c.PayloadType
 	configResult["recipients"] = c.Recipients
 	configResult["region"] = c.Region
@@ -176,7 +210,31 @@ func flattenAlertChannelConfiguration(c *alerts.ChannelConfiguration) []interfac
 	configResult["url"] = c.URL
 	configResult["user_id"] = c.UserID
 
-	return []interface{}{configResult}
+	if _, ok := d.GetOk("config.0.headers"); ok {
+		configResult["headers"] = c.Headers
+	} else if _, ok := d.GetOk("config.0.headers_string"); ok {
+		h, err := json.Marshal(c.Headers)
+
+		if err != nil {
+			return nil, err
+		}
+
+		configResult["headers_string"] = string(h)
+	}
+
+	if _, ok := d.GetOk("config.0.payload"); ok {
+		configResult["payload"] = c.Payload
+	} else if _, ok := d.GetOk("config.0.payload_string"); ok {
+		h, err := json.Marshal(c.Payload)
+
+		if err != nil {
+			return nil, err
+		}
+
+		configResult["payload_string"] = string(h)
+	}
+
+	return []interface{}{configResult}, nil
 }
 
 func flattenDeprecatedAlertChannelConfiguration(c *alerts.ChannelConfiguration) (map[string]interface{}, error) {

--- a/website/docs/r/alert_channel.html.markdown
+++ b/website/docs/r/alert_channel.html.markdown
@@ -136,9 +136,10 @@ resource "newrelic_alert_channel" "foo" {
 
   config {
     base_url = "http://www.test.com"
+    payload_type = "application/json"
     payload = {
-      condition_name: "$CONDITION_NAME"
-      policy_name: "$POLICY_NAME"
+      condition_name = "$CONDITION_NAME"
+      policy_name = "$POLICY_NAME"
     }
 
     headers = {
@@ -160,7 +161,7 @@ resource "newrelic_alert_channel" "foo" {
     payload_type = "application/json"
     payload_string = <<EOF
 {
-  "values": {
+  "my_custom_values": {
     "condition_name": "$CONDITION_NAME",
     "policy_name": "$POLICY_NAME"
   }

--- a/website/docs/r/alert_channel.html.markdown
+++ b/website/docs/r/alert_channel.html.markdown
@@ -48,7 +48,9 @@ Each alert channel type supports a specific set of arguments for the `config` bl
     * `auth_type` - (Optional) Specifies an authentication method for use with a channel.  Supported by the `webhook` channel type.  Only HTTP basic authentication is currently supported via the value `BASIC`.
     * `auth_username` - (Optional) Specifies an authentication username for use with a channel.  Supported by the `webhook` channel type.
     * `headers` - (Optional) A map of key/value pairs that represents extra HTTP headers to be sent along with the webhook payload.
-    * `payload` - (Optional) A map of key/value pairs that represents the webhook payload. Must provide `payload_type` if setting this argument.
+    * `headers_string` - (Optional) Use instead of `headers` if the desired payload is more complex than a list of key/value pairs (e.g. a set of headers that makes use of nested objects).  The value provided should be a valid JSON string with escaped double quotes. Conflicts with `headers`.
+    * `payload` - (Optional) A map of key/value pairs that represents the webhook payload.  Must provide `payload_type` if setting this argument.
+    * `payload_string` - (Optional) Use instead of `payload` if the desired payload is more complex than a list of key/value pairs (e.g. a payload that makes use of nested objects).  The value provided should be a valid JSON string with escaped double quotes. Conflicts with `payload`.
     * `payload_type` - (Optional) Can either be `application/json` or `application/x-www-form-urlencoded`. The `payload_type` argument is _required_ if `payload` is set.
   * `pagerduty`
     * `service_key` - (Required) Specifies the service key for integrating with Pagerduty.
@@ -122,6 +124,48 @@ resource "newrelic_alert_channel" "foo" {
   config {
     key       = "abc123"
     route_key = "/example"
+  }
+}
+```
+
+##### Webhook
+```hcl
+resource "newrelic_alert_channel" "foo" {
+  name = "webhook-example"
+  type = "webhook"
+
+  config {
+    base_url = "http://www.test.com"
+    payload = {
+      condition_name: "$CONDITION_NAME"
+      policy_name: "$POLICY_NAME"
+    }
+
+    headers = {
+      header1 = value1
+      header2 = value2
+    }
+  }
+}
+```
+
+##### Webhook with complex payload
+```hcl
+resource "newrelic_alert_channel" "foo" {
+  name = "webhook-example"
+  type = "webhook"
+
+  config {
+    base_url = "http://www.test.com"
+    payload_type = "application/json"
+    payload_string = <<EOF
+{
+  "values": {
+    "condition_name": "$CONDITION_NAME",
+    "policy_name": "$POLICY_NAME"
+  }
+}
+EOF
   }
 }
 ```


### PR DESCRIPTION
Resolves #382 .

This PR introduces two new config attributes for alert channels that use the webhook type, `payload_string` and `headers_string`.  They can be used to supply freeform JSON definitions for webhook `payload` and `headers` fields when a simple key/string value definition is not sufficient.