### PR TITLE
fix(alert_condition): mark condition_scope optional

### DIFF
--- a/newrelic/resource_newrelic_alert_condition.go
+++ b/newrelic/resource_newrelic_alert_condition.go
@@ -118,7 +118,7 @@ func resourceNewRelicAlertCondition() *schema.Resource {
 			},
 			"condition_scope": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"violation_close_timer": {
 				Type:         schema.TypeInt,

--- a/website/docs/r/alert_condition.html.markdown
+++ b/website/docs/r/alert_condition.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
   * `type` - (Required) The type of condition. One of: `apm_app_metric`, `apm_jvm_metric`, `apm_kt_metric`, `servers_metric`, `browser_metric`, `mobile_metric`
   * `entities` - (Required) The instance IDS associated with this condition.
   * `metric` - (Required) The metric field accepts parameters based on the `type` set.
-  * `condition_scope` - (Required) `application` or `instance`.  Choose `application` for most scenarios.  If you are using the JVM plugin in New Relic, the `instance` setting allows your condition to trigger [for specific app instances](https://docs.newrelic.com/docs/alerts/new-relic-alerts/defining-conditions/scope-alert-thresholds-specific-instances).
+  * `condition_scope` - (Required for some types) `application` or `instance`.  Choose `application` for most scenarios.  If you are using the JVM plugin in New Relic, the `instance` setting allows your condition to trigger [for specific app instances](https://docs.newrelic.com/docs/alerts/new-relic-alerts/defining-conditions/scope-alert-thresholds-specific-instances).
   * `gc_metric` - (Optional) A valid Garbage Collection metric e.g. `GC/G1 Young Generation`. This is required if you are using `apm_jvm_metric` with `gc_cpu_time` condition type.
   * `violation_close_timer` - (Optional) Automatically close instance-based violations, including JVM health metric violations, after the number of hours specified. Must be: `1`, `2`, `4`, `8`, `12` or `24`.
   * `runbook_url` - (Optional) Runbook URL to display in notifications.


### PR DESCRIPTION
resolves: #386

Without this change, the provider fores the user to set a condition_scope, which
is not a valid attribute on all alert condition types.  The apm_app_metric types
require it to be set, but the API throws back a message that we surface to the
user already.  Without this change though, users of other condition types, like
apm_kt_metric, are unable to get a clean run, because the condition_scope is not
valid for that type.