### PR TITLE
chore: update to newrelic-client-go v0.10.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
 	github.com/newrelic/go-agent/v3 v3.3.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go v0.9.0
+	github.com/newrelic/newrelic-client-go v0.10.0
 	github.com/stretchr/testify v1.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -375,8 +375,8 @@ github.com/newrelic/go-agent/v3 v3.3.0 h1:qcdu8gEsvRWCaKIN35Fr7sdwl7fk/DyVw2r1an
 github.com/newrelic/go-agent/v3 v3.3.0/go.mod h1:H28zDNUC0U/b7kLoY4EFOhuth10Xu/9dchozUiOseQQ=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go v0.9.0 h1:KgIGvDbe6rzmP35uM0FhS7sf7BhJTzUpNPKFGSxHzO0=
-github.com/newrelic/newrelic-client-go v0.9.0/go.mod h1:cy6GDp11OfIj8Wfg0jfzDycso91NcojANZUqnjU9+QM=
+github.com/newrelic/newrelic-client-go v0.10.0 h1:r1ujN0Eqo5u6xRm4U+zcPbMdcTp0sI/DCUshMVM2Q98=
+github.com/newrelic/newrelic-client-go v0.10.0/go.mod h1:cy6GDp11OfIj8Wfg0jfzDycso91NcojANZUqnjU9+QM=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=


### PR DESCRIPTION
Updating newrelic-client-go to v0.10.0