### PR TITLE
fix: import condition terms regardless of threshold format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk v1.8.0
 	github.com/newrelic/go-agent/v3 v3.3.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go v0.17.0
+	github.com/newrelic/newrelic-client-go v0.17.1
 	github.com/stretchr/testify v1.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -443,6 +443,8 @@ github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fz
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
 github.com/newrelic/newrelic-client-go v0.17.0 h1:a/oqoWVGTVblKbkYCb/FSn0mX55BvUm5BR4jHdWFdO8=
 github.com/newrelic/newrelic-client-go v0.17.0/go.mod h1:A2j/O6Wcy7z1sgI49wr5LGsg+5fj171BvPLJI6DmLI4=
+github.com/newrelic/newrelic-client-go v0.17.1 h1:a6pSQ+qQ6muXf9SBhWVGV6hDW04g5EOtbzYlkno5kIM=
+github.com/newrelic/newrelic-client-go v0.17.1/go.mod h1:A2j/O6Wcy7z1sgI49wr5LGsg+5fj171BvPLJI6DmLI4=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=

--- a/newrelic/resource_newrelic_alert_condition_test.go
+++ b/newrelic/resource_newrelic_alert_condition_test.go
@@ -118,6 +118,23 @@ func TestAccNewRelicAlertCondition_ZeroThreshold(t *testing.T) {
 	})
 }
 
+func TestAccNewRelicAlertCondition_FloatThreshold(t *testing.T) {
+	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNewRelicAlertConditionConfigThreshold(rName, 0.5),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAlertConditionExists("newrelic_alert_condition.foo"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNewRelicAlertCondition_AlertPolicyNotFound(t *testing.T) {
 	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
 
@@ -320,7 +337,7 @@ resource "newrelic_alert_condition" "foo" {
 `, name, testAccExpectedApplicationName)
 }
 
-func testAccNewRelicAlertConditionConfigThreshold(name string, threshold int) string {
+func testAccNewRelicAlertConditionConfigThreshold(name string, threshold float64) string {
 	return fmt.Sprintf(`
 data "newrelic_application" "app" {
 	name = "%[3]s"
@@ -343,7 +360,7 @@ resource "newrelic_alert_condition" "foo" {
 		duration      = 5
 		operator      = "below"
 		priority      = "critical"
-		threshold     = "%d"
+		threshold     = "%f"
 		time_function = "all"
 	}
 }

--- a/vendor/github.com/newrelic/newrelic-client-go/internal/version/version.go
+++ b/vendor/github.com/newrelic/newrelic-client-go/internal/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version of this library
-const Version string = "0.17.0"
+const Version string = "0.17.1"

--- a/vendor/github.com/newrelic/newrelic-client-go/pkg/alerts/serialization.go
+++ b/vendor/github.com/newrelic/newrelic-client-go/pkg/alerts/serialization.go
@@ -1,0 +1,32 @@
+package alerts
+
+import (
+	"encoding/json"
+	"strconv"
+)
+
+// UnmarshalJSON is responsible for unmarshaling the ConditionTerm type.
+func (c *ConditionTerm) UnmarshalJSON(data []byte) error {
+	var v map[string]interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	threshold, err := strconv.ParseFloat(v["threshold"].(string), 64)
+	if err != nil {
+		return err
+	}
+
+	duration, err := strconv.ParseInt(v["duration"].(string), 10, 32)
+	if err != nil {
+		return err
+	}
+
+	c.Threshold = threshold
+	c.Duration = int(duration)
+	c.Operator = OperatorType(v["operator"].(string))
+	c.Priority = PriorityType(v["priority"].(string))
+	c.TimeFunction = TimeFunctionType(v["time_function"].(string))
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -453,7 +453,7 @@ github.com/newrelic/go-agent/v3/internal/utilization
 github.com/newrelic/go-agent/v3/newrelic
 # github.com/newrelic/go-insights v1.0.3
 github.com/newrelic/go-insights/client
-# github.com/newrelic/newrelic-client-go v0.17.0
+# github.com/newrelic/newrelic-client-go v0.17.1
 github.com/newrelic/newrelic-client-go/internal/http
 github.com/newrelic/newrelic-client-go/internal/logging
 github.com/newrelic/newrelic-client-go/internal/region


### PR DESCRIPTION
Resolves #432 .

This PR integrates newrelic-client-go v0.17.1, which contains custom unmarshaling rules to deal with more formats for alert condition threshold values.