### PR TITLE
docs: use correct default synthetics_api_url in config docs

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -75,7 +75,7 @@ The following arguments are supported:
 
 - `api_key` - (Required except for `newrelic_insights_event` resource) Your New Relic API key. The `NEWRELIC_API_KEY` environment variable can also be used.
 - `api_url` - (Optional) This argument changes the main REST API URL (default is https://api.newrelic.com/v2). If the New Relic account is in the EU, the API URL must be set to https://api.eu.newrelic.com/v2. The `NEWRELIC_API_URL` environment variable can also be used.
-- `synthetics_api_url` - (Optional) This argument changes the Synthetics API URL (default is https://synthetics.newrelic.com/synthetics/api/v3). If the New Relic account is in the EU. the API URL must be set to https://synthetics.eu.newrelic.com/synthetics/api/v3. The `NEWRELIC_SYNTHETICS_API_URL` environment variable can also be used.  This URL is used to provision Synthetics monitors and monitor scripts only.
+- `synthetics_api_url` - (Optional) This argument changes the Synthetics API URL (default is https://synthetics.newrelic.com/synthetics/api). If the New Relic account is in the EU, the API URL must be set to https://synthetics.eu.newrelic.com/synthetics/api. The `NEWRELIC_SYNTHETICS_API_URL` environment variable can also be used.  This URL is used to provision Synthetics monitors and monitor scripts only.
 - `infrastructure_api_url` - (Optional) This argument changes the Infrastructure API URL (default is https://infra-api.newrelic.com/v2). If the New Relic account is in the EU, the Infra API URL must be set to https://infra-api.eu.newrelic.com/v2. The `NEWRELIC_INFRASTRUCTURE_API_URL` environment variable can also be used.  This URL is used to provision Infrastructure alert conditions only.
 - `infra_api_url` - (Deprecated) This argument operates the same as `infrastructure_api_url` above, but is deprecated and will be removed in a future version of the provider.
 - `insecure_skip_verify` - (Optional) Trust self-signed SSL certificates. If omitted, the `NEWRELIC_API_SKIP_VERIFY` environment variable is used.
@@ -94,7 +94,7 @@ Setting `TF_LOG` to a value of `DEBUG` will generate request log messages from t
 
 ## Community
 
-New Relic hosts and moderates an online forum where customers can interact with New Relic employees as well as other customers to get help and share best practices. 
+New Relic hosts and moderates an online forum where customers can interact with New Relic employees as well as other customers to get help and share best practices.
 
 * [Roadmap](https://newrelic.github.io/developer-toolkit/roadmap/) - As part of the Developer Toolkit, the roadmap for this project follows the same RFC process
 * [Issues or Enhancement Requests](https://github.com/terraform-providers/terraform-provider-newrelic/issues) - Issues and enhancement requests can be submitted in the Issues tab of this repository. Please search for and review the existing open issues before submitting a new issue.

--- a/website/docs/r/alert_condition.html.markdown
+++ b/website/docs/r/alert_condition.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 
   * `policy_id` - (Required) The ID of the policy where this condition should be used.
   * `name` - (Required) The title of the condition. Must be between 1 and 64 characters, inclusive.
-  * `type` - (Required) The type of condition. One of: `apm_app_metric`, `apm_jvm_metric`, `apm_kt_metric`, `browser_metric`, `mobile_metric`
+  * `type` - (Required) The type of condition. One of: `apm_app_metric`, `apm_kt_metric`, `browser_metric`, `mobile_metric`
   * `entities` - (Required) The instance IDs associated with this condition.
   * `metric` - (Required) The metric field accepts parameters based on the `type` set. One of these metrics based on `type`:
     * `apm_app_metric`
@@ -58,11 +58,6 @@ The following arguments are supported:
       * `throughput_background`
       * `throughput_web`
       * `user_defined`
-    * `apm_jvm_metric`
-      * `cpu_utilization_time`
-      * `deadlocked_threads`
-      * `gc_cpu_time`
-      * `heap_memory_usage`
     * `apm_kt_metric`
       * `apdex`
       * `error_count`
@@ -94,7 +89,7 @@ The following arguments are supported:
       * `view_loading`
   * `condition_scope` - (Required for some types) `application` or `instance`.  Choose `application` for most scenarios.  If you are using the JVM plugin in New Relic, the `instance` setting allows your condition to trigger [for specific app instances](https://docs.newrelic.com/docs/alerts/new-relic-alerts/defining-conditions/scope-alert-thresholds-specific-instances).
   * `enabled` - (Optional) Whether the condition is enabled or not. Defaults to true.
-  * `gc_metric` - (Optional) A valid Garbage Collection metric e.g. `GC/G1 Young Generation`. This is required if you are using `apm_jvm_metric` with `gc_cpu_time` condition type.
+  * `gc_metric` - (Optional) A valid Garbage Collection metric e.g. `GC/G1 Young Generation`.
   * `violation_close_timer` - (Optional) Automatically close instance-based violations, including JVM health metric violations, after the number of hours specified. Must be: `1`, `2`, `4`, `8`, `12` or `24`.
   * `runbook_url` - (Optional) Runbook URL to display in notifications.
   * `term` - (Required) A list of terms for this condition. See [Terms](#terms) below for details.


### PR DESCRIPTION
Resolves: #481 

This PR also removes the inaccessible alert condition type `apm_jvm_metric` from the docs.