### PR TITLE
chore(provider): add personal_api_key and account_id to provider schema and ProviderConfig

### DIFF
--- a/newrelic/config.go
+++ b/newrelic/config.go
@@ -155,4 +155,11 @@ type ProviderConfig struct {
 	NewClient            *nr.NewRelic
 	InsightsInsertClient *insights.InsertClient
 	InsightsQueryClient  *insights.QueryClient
+	AccountID            int
+	PersonalAPIKey       string
+}
+
+// nolint:unused
+func (c *ProviderConfig) hasNerdGraphCredentials() bool {
+	return c.AccountID > 0 && c.PersonalAPIKey != ""
 }

--- a/newrelic/provider.go
+++ b/newrelic/provider.go
@@ -23,6 +23,12 @@ const (
 func Provider() terraform.ResourceProvider {
 	provider := &schema.Provider{
 		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("NEWRELIC_ACCOUNT_ID", nil),
+				Sensitive:   true,
+			},
 			"api_key": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -190,6 +196,8 @@ func providerConfigure(data *schema.ResourceData, terraformVersion string) (inte
 		NewClient:            client,
 		InsightsInsertClient: clientInsightsInsert,
 		InsightsQueryClient:  clientInsightsQuery,
+		PersonalAPIKey:       personalAPIKey,
+		AccountID:            data.Get("account_id").(int),
 	}
 
 	return &providerConfig, nil

--- a/newrelic/provider_test.go
+++ b/newrelic/provider_test.go
@@ -46,6 +46,19 @@ func TestProviderImpl(t *testing.T) {
 	var _ terraform.ResourceProvider = Provider()
 }
 
+func TestProviderConfig(t *testing.T) {
+	c := ProviderConfig{
+		PersonalAPIKey: "abc123",
+		AccountID:      123,
+	}
+
+	hasNerdGraphCreds := c.hasNerdGraphCredentials()
+
+	if !hasNerdGraphCreds {
+		t.Error("hasNerdGraphCreds should be true")
+	}
+}
+
 func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("NEWRELIC_API_KEY"); v == "" {
 		t.Fatal("NEWRELIC_API_KEY must be set for acceptance tests")
@@ -53,6 +66,10 @@ func testAccPreCheck(t *testing.T) {
 
 	if v := os.Getenv("NEWRELIC_LICENSE_KEY"); v == "" {
 		t.Fatal("NEWRELIC_LICENSE_KEY must be set for acceptance tests")
+	}
+
+	if v := os.Getenv("NEWRELIC_PERSONAL_API_KEY"); v == "" {
+		t.Log("[WARN] NEWRELIC_PERSONAL_API_KEY has not been set for acceptance tests")
 	}
 
 	//testAccApplicationsCleanup(t)


### PR DESCRIPTION
This PR adds `AccountID` and `PersonalAPIKey` to `ProviderConfig` to facilitate logic for selecting which API to call (REST APIs or NerdGraph) via the helper method `ProviderConfig.hasNerdGraphCredentials()`.