### PR TITLE
Fix: violation_close_timer only applies to condition_scope instance

### DIFF
--- a/newrelic/resource_newrelic_alert_condition.go
+++ b/newrelic/resource_newrelic_alert_condition.go
@@ -200,13 +200,16 @@ func resourceNewRelicAlertCondition() *schema.Resource {
 
 func resourceNewRelicAlertConditionCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ProviderConfig).NewClient
-	condition := expandAlertCondition(d)
+	condition, err := expandAlertCondition(d)
+	if err != nil {
+		return err
+	}
 
 	policyID := d.Get("policy_id").(int)
 
 	log.Printf("[INFO] Creating New Relic alert condition %s", condition.Name)
 
-	condition, err := client.Alerts.CreateCondition(policyID, *condition)
+	condition, err = client.Alerts.CreateCondition(policyID, *condition)
 	if err != nil {
 		return err
 	}
@@ -256,7 +259,10 @@ func resourceNewRelicAlertConditionRead(d *schema.ResourceData, meta interface{}
 
 func resourceNewRelicAlertConditionUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ProviderConfig).NewClient
-	condition := expandAlertCondition(d)
+	condition, err := expandAlertCondition(d)
+	if err != nil {
+		return err
+	}
 
 	ids, err := parseIDs(d.Id(), 2)
 	if err != nil {

--- a/newrelic/resource_newrelic_alert_condition.go
+++ b/newrelic/resource_newrelic_alert_condition.go
@@ -126,9 +126,10 @@ func resourceNewRelicAlertCondition() *schema.Resource {
 				Description: "Runbook URL to display in notifications.",
 			},
 			"condition_scope": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "One of (application, instance). Choose application for most scenarios. If you are using the JVM plugin in New Relic, the instance setting allows your condition to trigger for specific app instances.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"application", "instance"}, false),
+				Description:  "One of (application, instance). Choose application for most scenarios. If you are using the JVM plugin in New Relic, the instance setting allows your condition to trigger for specific app instances.",
 			},
 			"violation_close_timer": {
 				Type:         schema.TypeInt,


### PR DESCRIPTION
Previously, violation_close_timer was not validated to be only applied when condition_scope was properly set. The [docs](https://docs.newrelic.com/docs/alerts/rest-api-alerts/new-relic-alerts-rest-api/alerts-conditions-api-field-names#violation_close_timer) state that this option is only valid when targeting `instance` not `application`, and the result was constant drift in the resource.

### Example Configuration

```
resource "newrelic_alert_condition" "test" {
  name = "test"
   
  condition_scope = "application"
  enabled         = true
  entities = [
    data.newrelic_application.test.id,
  ]
  metric                      = "user_defined"
  policy_id                   = newrelic_alert_policy.test.id
  type                        = "apm_app_metric"
  user_defined_metric         = "Go/Runtime/Goroutines"
  user_defined_value_function = "average"
  violation_close_timer       = 24
   
  term {
    duration      = 5
    operator      = "below"
    priority      = "critical"
    threshold     = 10
    time_function = "all"
  }
}
```

### Drift

```
# newrelic_alert_condition.test must be replaced
-/+ resource "newrelic_alert_condition" "test" {
....
      ~ violation_close_timer       = 0 -> 24
...
```

### Resolution

This modifies `newrelic_alert_condition` such that:
* Validates `condition_scope` to be one of `application`, `instance`
* Throw an error if `validation_close_timer` is set, and `condition_scope` is not `instance`
