### PR TITLE
docs(alert_channel): fix broken 'nested config' anchor link

### DIFF
--- a/website/docs/r/alert_channel.html.markdown
+++ b/website/docs/r/alert_channel.html.markdown
@@ -32,7 +32,7 @@ The following arguments are supported:
 
   * `name` - (Required) The name of the channel.
   * `type` - (Required) The type of channel.  One of: `email`, `slack`, `opsgenie`, `pagerduty`, `victorops`, or `webhook`.
-  * `config` - (Optional) A nested block that describes an alert channel configuration.  Only one config block is permitted per alert channel definition.  See [Nested config blocks](#nested-`config`-blocks) below for details.
+  * `config` - (Optional) A nested block that describes an alert channel configuration.  Only one config block is permitted per alert channel definition.  See [Nested config blocks](#nested-config-blocks) below for details.
   * `configuration` - **Deprecated** (Optional) A map of key/value pairs with channel type specific values. This argument is deprecated.  Use the `config` argument instead.
 
 ### Nested `config` blocks


### PR DESCRIPTION
This PR fixes a broken link within the `newrelic_alert_channel` resource documentation.