### PR TITLE
docs(getting started): fix resource naming

### DIFF
--- a/website/docs/guides/getting_started.html.markdown
+++ b/website/docs/guides/getting_started.html.markdown
@@ -46,7 +46,7 @@ Let's start with a minimal Terraform config file to create an Alert Policy.
 ```hcl
 provider "newrelic" {}
 
-resource "newrelic_alert_policy" "my_alert_policy_name" {
+resource "newrelic_alert_policy" "alert_policy_name" {
   name = "My Alert Policy Name"
 }
 ```
@@ -85,7 +85,7 @@ data "newrelic_application" "app_name" {
   name = "my-app" # Note: This must be an exact match of your app name in New Relic (Case sensitive)
 }
 
-resource "newrelic_alert_policy" "my_alert_policy_name" {
+resource "newrelic_alert_policy" "alert_policy_name" {
   name = "My Alert Policy Name"
 }
 ```
@@ -108,7 +108,7 @@ resource "newrelic_alert_policy" "alert_policy_name" {
 
 # Alert Condition
 resource "newrelic_alert_condition" "alert_condition_name" {
-  policy_id = newrelic_alert_policy.my_alert_policy_name.id
+  policy_id = newrelic_alert_policy.alert_policy_name.id
 
   name            = "My Alert Condition Name"
   type            = "apm_app_metric"
@@ -149,7 +149,7 @@ resource "newrelic_alert_channel" "alert_notification_email" {
 
 # Link the above notification channel to your policy
 resource "newrelic_alert_policy_channel" "alert_policy_email" {
-  policy_id  = newrelic_alert_policy.my_alert_policy_name.id
+  policy_id  = newrelic_alert_policy.alert_policy_name.id
   channel_ids = [
     newrelic_alert_channel.alert_notification_email.id
   ]


### PR DESCRIPTION
Rename "my_alert_policy_name" to "alert_policy_name" in the Getting Started guide.
Previously both names were used, resulting in errors
when trying to run terraform after pasting the code from docs.

`alert_policy_name` was used on line 105, while other lines used `my_alert_policy_name`.

Since no other resource names start with `my_`, I've decided to keep it as `alert_policy_name`.