### PR TITLE
chore(build): Ask renovate to track release/v1.x branch too

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,8 @@
 {
+  "baseBranches": [
+    "master",
+    "release/v1.x"
+  ],
   "extends": [
     "config:base"
   ],


### PR DESCRIPTION
So the `release/v1.x` branch does not get out of date while we aren't looking.