### PR TITLE
tests: fix integration tests

### DIFF
--- a/newrelic/resource_newrelic_application_settings_test.go
+++ b/newrelic/resource_newrelic_application_settings_test.go
@@ -57,10 +57,12 @@ resource "newrelic_application_settings" "app" {
 `, testAccExpectedApplicationName)
 }
 
+// The application name should NOT be updated here since it is shared
+// between all of the other integration tests.
 func testAccNewRelicApplicationConfigUpdated(name string) string {
 	return fmt.Sprintf(`
 resource "newrelic_application_settings" "app" {
-	name = "%s-updated"
+	name = "%s"
 	app_apdex_threshold = "0.8"
 	end_user_apdex_threshold = "0.7"
 	enable_real_user_monitoring = false

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -41,6 +41,7 @@ resource "newrelic_alert_condition" "foo" {
   entities    = [data.newrelic_application.foo.id]
   metric      = "apdex"
   runbook_url = "https://docs.example.com/my-runbook"
+  condition_scope = "application"
 
   term {
     duration      = 5


### PR DESCRIPTION
Stop updating the application name under test since it is shared by all the other tests.