### PR TITLE
chore(stale): don't close PRs or issues with 'pinned' label

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -19,6 +19,7 @@ exemptLabels:
   - priority:high
   - priority:blocker
   - good first issue
+  - pinned
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false


### PR DESCRIPTION
Some issues were being marked as `stale` even though we know we're going to be handling them in the future. Adding the `pinned` label to ensure we don't close tickets or PRs that fall into this scenario.