### PR TITLE
chore(alerts): deprecation notice for direct use of "terms"

### DIFF
--- a/examples/modules/golden-signal-alerts/main.tf
+++ b/examples/modules/golden-signal-alerts/main.tf
@@ -15,11 +15,10 @@ resource "newrelic_alert_condition" "response_time_web" {
 	metric          = "response_time_web"
 	condition_scope = "application"
 
-	term {
+	critical {
 		duration      = var.service.duration
 		threshold     = var.service.response_time_threshold
 		operator      = "above"
-		priority      = "critical"
 		time_function = "all"
 	}
 }
@@ -33,11 +32,10 @@ resource "newrelic_alert_condition" "throughput_web" {
 	metric          = "throughput_web"
 	condition_scope = "application"
 
-	term {
+	critical {
 		duration      = var.service.duration
 		threshold     = var.service.throughput_threshold
 		operator      = "below"
-		priority      = "critical"
 		time_function = "all"
 	}
 }
@@ -51,11 +49,10 @@ resource "newrelic_alert_condition" "error_percentage" {
 	metric          = "error_percentage"
 	condition_scope = "application"
 
-	term {
+	critical {
 		duration      = var.service.duration
 		threshold     = var.service.error_percentage_threshold
 		operator      = "above"
-		priority      = "critical"
 		time_function = "all"
 	}
 }

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -70,6 +70,9 @@ func termSchema() *schema.Resource {
 				Description:   "The criteria for how many data points must be in violation for the specified threshold duration. Valid values are: 'ALL' or 'AT_LEAST_ONCE' (case insensitive).",
 				ConflictsWith: []string{"term.0.time_function"},
 				ValidateFunc:  validation.StringInSlice([]string{"ALL", "AT_LEAST_ONCE"}, true),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.EqualFold(old, new) // Case fold this attribute when diffing
+				},
 			},
 			// NerdGraph only. Equivalent to `duration`, but in seconds
 			"threshold_duration": {

--- a/newrelic/structures_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/newrelic/newrelic-client-go/pkg/alerts"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	nr "github.com/newrelic/newrelic-client-go/pkg/testhelpers"
@@ -15,13 +16,25 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 		"evaluation_offset": 3,
 	}
 
+	var criticalTerms []map[string]interface{}
+	criticalTerms = append(criticalTerms, map[string]interface{}{
+		"threshold":             1,
+		"threshold_occurrences": alerts.ThresholdOccurrences.AtLeastOnce,
+		"threshold_duration":    600,
+		"operator":              alerts.NrqlConditionOperators.Above,
+	})
+
+	var warningTerms []map[string]interface{}
+	warningTerms = append(warningTerms, map[string]interface{}{
+		"threshold":             9.1,
+		"threshold_occurrences": alerts.ThresholdOccurrences.AtLeastOnce,
+		"threshold_duration":    660,
+		"operator":              alerts.NrqlConditionOperators.Below,
+	})
+
 	expectedNrql := &alerts.NrqlConditionInput{}
 	expectedNrql.Nrql.Query = nrql["query"].(string)
 	expectedNrql.Nrql.EvaluationOffset = nrql["evaluation_offset"].(int)
-
-	// warningTerm := map[string]interface{}{}
-	//
-	// criticalTerm := map[string]interface{}{}
 
 	cases := map[string]struct {
 		Data         map[string]interface{}
@@ -81,6 +94,66 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 				ValueFunction: &alerts.NrqlConditionValueFunctions.SingleValue,
 			},
 		},
+		"critical term": {
+			Data: map[string]interface{}{
+				"nrql":           []interface{}{nrql},
+				"type":           "static",
+				"value_function": "single_value",
+				"critical":       criticalTerms,
+			},
+			ExpectErr:    false,
+			ExpectReason: "",
+			Expanded: func() *alerts.NrqlConditionInput {
+				x := alerts.NrqlConditionInput{
+					ValueFunction: &alerts.NrqlConditionValueFunctions.SingleValue,
+				}
+				x.Terms = []alerts.NrqlConditionTerm{
+					{
+						Threshold:            1,
+						ThresholdOccurrences: alerts.ThresholdOccurrences.AtLeastOnce,
+						ThresholdDuration:    600,
+						Operator:             alerts.NrqlConditionOperators.Above,
+						Priority:             alerts.NrqlConditionPriorities.Critical,
+					},
+				}
+
+				return &x
+			}(),
+		},
+		"critical and warning terms": {
+			Data: map[string]interface{}{
+				"nrql":           []interface{}{nrql},
+				"type":           "static",
+				"value_function": "single_value",
+				"critical":       criticalTerms,
+				"warning":        warningTerms,
+			},
+			ExpectErr:    false,
+			ExpectReason: "",
+			Expanded: func() *alerts.NrqlConditionInput {
+				x := alerts.NrqlConditionInput{
+					ValueFunction: &alerts.NrqlConditionValueFunctions.SingleValue,
+				}
+				x.Terms = []alerts.NrqlConditionTerm{
+					{
+						Threshold:            1,
+						ThresholdOccurrences: alerts.ThresholdOccurrences.AtLeastOnce,
+						ThresholdDuration:    600,
+						Operator:             alerts.NrqlConditionOperators.Above,
+						Priority:             alerts.NrqlConditionPriorities.Critical,
+					},
+					{
+						Threshold:            9.1,
+						ThresholdOccurrences: alerts.ThresholdOccurrences.AtLeastOnce,
+						ThresholdDuration:    660,
+						Operator:             alerts.NrqlConditionOperators.Below,
+						Priority:             alerts.NrqlConditionPriorities.Warning,
+					},
+				}
+
+				return &x
+			}(),
+		},
 	}
 
 	r := resourceNewRelicNrqlAlertCondition()
@@ -89,8 +162,21 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 		d := r.TestResourceData()
 
 		for k, v := range tc.Data {
-			if err := d.Set(k, v); err != nil {
-				t.Fatalf("err: %s", err)
+			if k == "critical" || k == "warning" {
+				var terms []map[string]interface{}
+
+				for _, namedTerm := range v.([]map[string]interface{}) {
+					terms = append(terms, namedTerm)
+				}
+
+				if err := d.Set(k, terms); err != nil {
+					t.Fatalf("err: %s", err)
+				}
+
+			} else {
+				if err := d.Set(k, v); err != nil {
+					t.Fatalf("err: %s", err)
+				}
 			}
 		}
 
@@ -121,6 +207,10 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 			if tc.Expanded.Nrql.EvaluationOffset > 0 {
 				require.Equal(t, tc.Expanded.Nrql.EvaluationOffset, expanded.Nrql.EvaluationOffset)
 			}
+
+			if len(tc.Expanded.Terms) > 0 {
+				assert.Equal(t, tc.Expanded.Terms, expanded.Terms)
+			}
 		}
 	}
 }
@@ -147,6 +237,13 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 					ThresholdDuration:    600,
 					Operator:             alerts.NrqlConditionOperators.Above,
 					Priority:             alerts.NrqlConditionPriorities.Critical,
+				},
+				{
+					Threshold:            9.1,
+					ThresholdOccurrences: alerts.ThresholdOccurrences.AtLeastOnce,
+					ThresholdDuration:    660,
+					Operator:             alerts.NrqlConditionOperators.Below,
+					Priority:             alerts.NrqlConditionPriorities.Warning,
 				},
 			},
 			ViolationTimeLimit: alerts.NrqlConditionViolationTimeLimits.OneHour,
@@ -184,6 +281,22 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 
 		require.Equal(t, 7654321, d.Get("policy_id").(int))
 		require.Equal(t, nr.TestAccountID, d.Get("account_id").(int))
+
+		criticalTerms := d.Get("critical").([]interface{})
+		assert.Equal(t, 1, len(criticalTerms))
+		assert.Equal(t, float64(1), criticalTerms[0].(map[string]interface{})["threshold"])
+		assert.Equal(t, "AT_LEAST_ONCE", criticalTerms[0].(map[string]interface{})["threshold_occurrences"])
+		assert.Equal(t, 600, criticalTerms[0].(map[string]interface{})["threshold_duration"])
+		assert.Equal(t, "above", criticalTerms[0].(map[string]interface{})["operator"])
+
+		warningTerms := d.Get("warning").([]interface{})
+		assert.Equal(t, 1, len(warningTerms))
+		assert.Equal(t, float64(9.1), warningTerms[0].(map[string]interface{})["threshold"])
+		assert.Equal(t, "AT_LEAST_ONCE", warningTerms[0].(map[string]interface{})["threshold_occurrences"])
+		assert.Equal(t, 660, warningTerms[0].(map[string]interface{})["threshold_duration"])
+		assert.Equal(t, "below", warningTerms[0].(map[string]interface{})["operator"])
+
+		// require.Equal(t, 1, d.Get("critical.threshold").(map[string]interface{}))
 
 		switch condition.Type {
 		case alerts.NrqlConditionTypes.Baseline:

--- a/newrelic/structures_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition_test.go
@@ -165,9 +165,7 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 			if k == "critical" || k == "warning" {
 				var terms []map[string]interface{}
 
-				for _, namedTerm := range v.([]map[string]interface{}) {
-					terms = append(terms, namedTerm)
-				}
+				terms = append(terms, v.([]map[string]interface{})...)
 
 				if err := d.Set(k, terms); err != nil {
 					t.Fatalf("err: %s", err)

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -142,17 +142,15 @@ resource "newrelic_nrql_alert_condition" "foo" {
     evaluation_offset = 3
   }
 
-  term {
+  critical {
     operator              = "above"
-    priority              = "critical"
     threshold             = 5.5
     threshold_duration    = 300
     threshold_occurrences = "all"
   }
 
-  term {
+  warning {
     operator              = "above"
-    priority              = "warning"
     threshold             = 3.5
     threshold_duration    = 600
     threshold_occurrences = "all"
@@ -192,17 +190,15 @@ resource "newrelic_nrql_alert_condition" "foo" {
     evaluation_offset = 3
   }
 
-  term {
+  critical {
     operator              = "above"
-    priority              = "critical"
     threshold             = 0.002
     threshold_duration    = 600
     threshold_occurrences = "all"
   }
 
-  term {
+  warning {
     operator              = "above"
-    priority              = "warning"
     threshold             = 0.0015
     threshold_duration    = 600
     threshold_occurrences = "all"

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -69,8 +69,8 @@ The following arguments are supported:
 - `enabled` - (Optional) Whether to enable the alert condition. Valid values are `true` and `false`. Defaults to `true`.
 - `nrql` - (Required) A NRQL query. See [NRQL](#nrql) below for details.
 - `term` - (Optional) **DEPRECATED** Use `critical`, and `warning` instead.  A list of terms for this condition. See [Terms](#terms) below for details.
-- `critical` - (Required) A one-item list of a term for this condition with `critical` priority. See [Terms](#terms) below for details.
-- `warning` - (Optional) A one-item list of a term for this condition with `warning` priority. See [Terms](#terms) below for details.
+- `critical` - (Required) A list containing the `critical` threshold values. See [Terms](#terms) below for details.
+- `warning` - (Optional) A list containing the `warning` threshold values. See [Terms](#terms) below for details.
 - `value_function` - (Optional) Possible values are `single_value`, `sum` (case insensitive). Defaults to `single_value`.
 - `expected_groups` - (Optional) Number of expected groups when using `outlier` detection.
 - `open_violation_on_group_overlap` - (Optional) Whether or not to trigger a violation when groups overlap. Set to `true` if you want to trigger a violation when groups overlap. This argument is only applicable in `outlier` conditions.

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -38,17 +38,15 @@ resource "newrelic_nrql_alert_condition" "foo" {
     evaluation_offset = 3
   }
 
-  term {
+  critical {
     operator              = "above"
-    priority              = "critical"
     threshold             = 5.5
     threshold_duration    = 300
     threshold_occurrences = "ALL"
   }
 
-  term {
+  warning {
     operator              = "above"
-    priority              = "warning"
     threshold             = 3.5
     threshold_duration    = 600
     threshold_occurrences = "ALL"
@@ -70,7 +68,9 @@ The following arguments are supported:
 - `runbook_url` - (Optional) Runbook URL to display in notifications.
 - `enabled` - (Optional) Whether to enable the alert condition. Valid values are `true` and `false`. Defaults to `true`.
 - `nrql` - (Required) A NRQL query. See [NRQL](#nrql) below for details.
-- `term` - (Required) A list of terms for this condition. See [Terms](#terms) below for details.
+- `term` - (Optional) **DEPRECATED** Use `critical`, and `warning` instead.  A list of terms for this condition. See [Terms](#terms) below for details.
+- `critical` - (Required) A one-item list of a term for this condition with `critical` priority. See [Terms](#terms) below for details.
+- `warning` - (Optional) A one-item list of a term for this condition with `warning` priority. See [Terms](#terms) below for details.
 - `value_function` - (Optional) Possible values are `single_value`, `sum` (case insensitive). Defaults to `single_value`.
 - `expected_groups` - (Optional) Number of expected groups when using `outlier` detection.
 - `open_violation_on_group_overlap` - (Optional) Whether or not to trigger a violation when groups overlap. Set to `true` if you want to trigger a violation when groups overlap. This argument is only applicable in `outlier` conditions.
@@ -87,6 +87,8 @@ The `nrql` block supports the following arguments:
 - `since_value` - (Optional)  **DEPRECATED:** Use `evaluation_offset` instead. The value to be used in the `SINCE <X> minutes ago` clause for the NRQL query. Must be between 1-20 (inclusive).
 
 ## Terms
+
+~> **NOTE:** The direct use of the `term` has been deprecated, and users should use `critical` and `warning` instead.  What follows now applies to the named priority attributes for `critical` and `warning`, but for those attributes the priority is not allowed.
 
 NRQL alert conditions support up to two terms. At least one `term` must have `priority` set to `critical` and the second optional `term` must have `priority` set to `warning`.
 


### PR DESCRIPTION
resolves: #631

The named condition priorities "warning" and "critical" are promoted to replace the use of "terms" on a `newrelic_nrql_alert_condition` resource.